### PR TITLE
Add duplicate workout functionality

### DIFF
--- a/app/workouts/WorkoutModal.tsx
+++ b/app/workouts/WorkoutModal.tsx
@@ -66,7 +66,7 @@ export default function WorkoutModal({
     // TODO: Replace this function with a server action
     event.preventDefault();
 
-    if (!editWorkoutValue) {
+    if (!editWorkoutValue || editWorkoutValue.id === -2) {
       // If adding, just add new workout on to the end
       await addToDB();
       router.refresh();

--- a/app/workouts/Workouts.tsx
+++ b/app/workouts/Workouts.tsx
@@ -20,7 +20,8 @@ export default function Workouts({
 }) {
   const router = useRouter();
 
-  const [modalOpen, setModalOpen] = useState(false);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [duplicateModalOpen, setDuplicateModalOpen] = useState(false);
   const [workoutToDelete, setWorkoutToDelete] = useState(-1);
 
   const getDate = (date: Date | null) => {
@@ -36,7 +37,7 @@ export default function Workouts({
       .then((response) => {
         if (response.ok) {
           setWorkoutToDelete(-1);
-          setModalOpen(false);
+          setDeleteModalOpen(false);
           router.refresh();
         } else {
           console.log("Failed to delete exercise.");
@@ -47,6 +48,13 @@ export default function Workouts({
       });
   };
 
+  const duplicateWorkout = () => {
+    // Prefill modal with this workout, but with the sets and notes removed
+    // Ideally would have this in the edit screen, but that presents the issue of
+    // potentially having two modals on the screen at once
+    console.log("duplicating workout");
+  };
+
   workouts.sort((a, b) => b.date.getTime() - a.date.getTime());
 
   return (
@@ -55,17 +63,27 @@ export default function Workouts({
         <AccordionItem key={index} value={`item-${index}`}>
           <AccordionTrigger>{workout.name}</AccordionTrigger>
           <AccordionContent>
-            <Button
-              onClick={() => {
-                setModalOpen(true);
-                setWorkoutToDelete(workout.id);
-              }}
-              className="absolute right-5 py-1 px-2"
-              variant="destructive"
-            >
-              Delete
-            </Button>
-            <div onClick={() => editWorkout(workout)}>
+            <div className="text-right">
+              <Button
+                onClick={() => {
+                  setDuplicateModalOpen(true);
+                }}
+                className="mr-4 bg-blue-600 py-1 px-2"
+              >
+                Duplicate
+              </Button>
+              <Button
+                onClick={() => {
+                  setDeleteModalOpen(true);
+                  setWorkoutToDelete(workout.id);
+                }}
+                className="py-1 px-2"
+                variant="destructive"
+              >
+                Delete
+              </Button>
+            </div>
+            <div onClick={() => editWorkout(workout)} className="text-center">
               <div className="p-2 text-left">{getDate(workout.date)}</div>
               <div className="divide-y-2 px-2">
                 {workout.exercises.map((exercise: Exercise) => (
@@ -79,14 +97,17 @@ export default function Workouts({
           </AccordionContent>
         </AccordionItem>
       ))}
-      <Modal isOpen={modalOpen} handleClose={() => setModalOpen(false)}>
+      <Modal
+        isOpen={deleteModalOpen}
+        handleClose={() => setDeleteModalOpen(false)}
+      >
         <div className="fixed top-1/3 left-1/2 z-10 max-h-[80%] w-56 translate-x-[-50%] overflow-scroll rounded-lg bg-white p-5 text-center">
           Delete workout?
           <div className="mt-4 flex justify-around">
             <Button
               variant="outline"
               onClick={() => {
-                setModalOpen(false);
+                setDeleteModalOpen(false);
                 setWorkoutToDelete(-1);
               }}
             >
@@ -94,6 +115,28 @@ export default function Workouts({
             </Button>
             <Button variant="destructive" onClick={deleteWorkout}>
               Delete
+            </Button>
+          </div>
+        </div>
+      </Modal>
+      <Modal
+        isOpen={duplicateModalOpen}
+        handleClose={() => setDuplicateModalOpen(false)}
+      >
+        <div className="fixed top-1/3 left-1/2 z-10 max-h-[80%] w-56 translate-x-[-50%] overflow-scroll rounded-lg bg-white p-5 text-center">
+          Duplicate Workout?
+          <div className="mt-4 flex justify-around">
+            {/* TODO: Add description text here */}
+            <Button
+              variant="outline"
+              onClick={() => {
+                setDuplicateModalOpen(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button className="bg-blue-600 " onClick={duplicateWorkout}>
+              Duplicate
             </Button>
           </div>
         </div>

--- a/app/workouts/Workouts.tsx
+++ b/app/workouts/Workouts.tsx
@@ -23,6 +23,7 @@ export default function Workouts({
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [duplicateModalOpen, setDuplicateModalOpen] = useState(false);
   const [workoutToDelete, setWorkoutToDelete] = useState(-1);
+  const [workoutToDuplicate, setWorkoutToDuplicate] = useState(-1);
 
   const getDate = (date: Date | null) => {
     if (date) {
@@ -49,10 +50,26 @@ export default function Workouts({
   };
 
   const duplicateWorkout = () => {
-    // Prefill modal with this workout, but with the sets and notes removed
-    // Ideally would have this in the edit screen, but that presents the issue of
-    // potentially having two modals on the screen at once
-    console.log("duplicating workout");
+    // May be faster to just pass the entire workout to state rather than finding it
+    const workout = workouts.find(
+      (workout) => workout.id === workoutToDuplicate
+    );
+    if (workout) {
+      const workoutCopy = structuredClone(workout);
+      // Set id to -2 so submit logic knows it's duplicate
+      workoutCopy.id = -2;
+      workoutCopy.date = new Date();
+      workoutCopy.name = `Copy of ${workout.name}`;
+      // Clear all weight and notes for new workout
+      for (const exercise of workoutCopy.exercises) {
+        exercise.notes = "";
+        for (const set of exercise.sets) {
+          set.weight = "";
+        }
+      }
+      setDuplicateModalOpen(false);
+      editWorkout(workoutCopy);
+    }
   };
 
   workouts.sort((a, b) => b.date.getTime() - a.date.getTime());
@@ -67,6 +84,7 @@ export default function Workouts({
               <Button
                 onClick={() => {
                   setDuplicateModalOpen(true);
+                  setWorkoutToDuplicate(workout.id);
                 }}
                 className="mr-4 bg-blue-600 py-1 px-2"
               >
@@ -82,6 +100,10 @@ export default function Workouts({
               >
                 Delete
               </Button>
+              {/* 
+                  TODO: Consider adding the edit workout functionality to this toolbar rather than the unintuitive tapping the area
+                  Would reduve chance of accidental input as well
+               */}
             </div>
             <div onClick={() => editWorkout(workout)} className="text-center">
               <div className="p-2 text-left">{getDate(workout.date)}</div>
@@ -125,8 +147,8 @@ export default function Workouts({
       >
         <div className="fixed top-1/3 left-1/2 z-10 max-h-[80%] w-56 translate-x-[-50%] overflow-scroll rounded-lg bg-white p-5 text-center">
           Duplicate Workout?
+          {/* TODO: Does this really need a confirmation modal? */}
           <div className="mt-4 flex justify-around">
-            {/* TODO: Add description text here */}
             <Button
               variant="outline"
               onClick={() => {


### PR DESCRIPTION
We would like to give the user the ability to start with an existing workout as a template rather than create a workout from scratch each time. This update adds a duplicate button which will prefill the create workout modal with the the data from the selected workout, but with the notes and weights cleared out.