### PR TITLE
Add as child prop to buttons

### DIFF
--- a/app/exercises/ExerciseSummary.tsx
+++ b/app/exercises/ExerciseSummary.tsx
@@ -64,7 +64,7 @@ export default function ExerciseSummaryComponent({
     <div className="flex flex-col gap-2">
       <div className="self-start">
         <Dialog>
-          <DialogTrigger>
+          <DialogTrigger asChild>
             <Button className="text-lg">History</Button>
           </DialogTrigger>
           <DialogContent>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ export default function Home() {
     <div className="mx-auto max-w-4xl p-4 text-center">
       <h1 className="mb-5 text-2xl">Welcome to the Lifting Log!</h1>
       <div className="flex flex-col justify-center gap-4 sm:flex-row">
-        <div className="border-2 border-black p-3">
+        <div className="border-2 border-black dark:border-white p-3">
           <h1 className="text-lg font-bold">Workouts</h1>
           <p className="mb-2">
             Create, view and edit your workouts. Log all your sets and reps, as
@@ -16,7 +16,7 @@ export default function Home() {
             <Link href="/workouts">View Workouts</Link>
           </Button>
         </div>
-        <div className="border-2 border-black p-3">
+        <div className="border-2 border-black dark:border-white p-3">
           <h1 className="text-lg font-bold">Exercises</h1>
           <p className="mb-2">
             See all your exercises in one place, compare the same exercise

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,7 +12,7 @@ export default function Home() {
             Create, view and edit your workouts. Log all your sets and reps, as
             well as any notes you have about your workout.
           </p>
-          <Button>
+          <Button asChild>
             <Link href="/workouts">View Workouts</Link>
           </Button>
         </div>
@@ -22,7 +22,7 @@ export default function Home() {
             See all your exercises in one place, compare the same exercise
             across different days to see your progress.
           </p>
-          <Button>
+          <Button asChild>
             <Link href="/exercises">View Exercises</Link>
           </Button>
         </div>

--- a/app/workouts/WorkoutNotFound.tsx
+++ b/app/workouts/WorkoutNotFound.tsx
@@ -7,7 +7,7 @@ export default function WorkoutNotFound() {
       <p className="text-left mb-4">
         Workout not found, please return to the Workouts page
       </p>
-      <Button>
+      <Button asChild>
         <Link href="/workouts">Workouts</Link>
       </Button>
     </div>

--- a/app/workouts/Workouts.tsx
+++ b/app/workouts/Workouts.tsx
@@ -59,24 +59,32 @@ export default function Workouts({ workouts }: { workouts: Workout[] }) {
           </AccordionTrigger>
           <AccordionContent>
             <div className="flex justify-start gap-4 pt-2">
-              <Link
-                href={{
-                  pathname: "/workouts/edit",
-                  query: { id: workout.id },
-                }}
-                className="flex w-16 flex-col justify-center rounded-md bg-green-500 text-white hover:bg-green-500/70"
+              <Button
+                asChild
+                className="bg-green-500 text-white hover:bg-green-500/70"
               >
-                Edit
-              </Link>
-              <Link
-                href={{
-                  pathname: "/workouts/duplicate",
-                  query: { id: workout.id },
-                }}
-                className="flex w-24 flex-col justify-center rounded-md bg-blue-600 text-white hover:bg-blue-600/70"
+                <Link
+                  href={{
+                    pathname: "/workouts/edit",
+                    query: { id: workout.id },
+                  }}
+                >
+                  Edit
+                </Link>
+              </Button>
+              <Button
+                asChild
+                className="bg-blue-600 text-white hover:bg-blue-600/70"
               >
-                Duplicate
-              </Link>
+                <Link
+                  href={{
+                    pathname: "/workouts/duplicate",
+                    query: { id: workout.id },
+                  }}
+                >
+                  Duplicate
+                </Link>
+              </Button>
               <AlertDialog>
                 <AlertDialogTrigger asChild>
                   <Button variant="destructive">Delete</Button>

--- a/app/workouts/duplicate/page.tsx
+++ b/app/workouts/duplicate/page.tsx
@@ -45,22 +45,26 @@ const convertToFormType = (
 };
 
 export default async function DuplicateWorkoutPage({
-  params,
+  searchParams,
 }: {
-  params: Promise<{ id: number }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
-  const workoutId = (await params).id;
-  const workout = await getWorkout(workoutId);
+  const { id } = await searchParams;
+
+  if (typeof id !== "string" || isNaN(+id))
+    return <WorkoutNotFound></WorkoutNotFound>;
+
+  const workout = await getWorkout(+id);
 
   if (!workout) {
     return <WorkoutNotFound></WorkoutNotFound>;
-  } else {
-    return (
-      <WorkoutForm
-        workoutValue={workout}
-        editMode={false}
-        workoutId={-1}
-      ></WorkoutForm>
-    );
   }
+
+  return (
+    <WorkoutForm
+      workoutValue={workout}
+      editMode={false}
+      workoutId={-1}
+    ></WorkoutForm>
+  );
 }

--- a/app/workouts/page.tsx
+++ b/app/workouts/page.tsx
@@ -40,7 +40,7 @@ export default async function WorkoutsPage() {
   return (
     <div className="p-5 text-center">
       <h1 className="mb-5 text-3xl">Workouts</h1>
-      <Button>
+      <Button asChild>
         <Link href="/workouts/create">Add Workout</Link>
       </Button>
       <Workouts workouts={workouts}></Workouts>


### PR DESCRIPTION
Add asChild prop to buttons to improve performance and fix janky interactions. This relevant in places where there is an element nested within a Button, specifically a Link component. asChild will render and actual link tag in the dom, but with the styling of the Button component.

[Radix UI Documentation](https://www.radix-ui.com/primitives/docs/guides/composition)

This PR contains some other miscellaneous changes such as a fix to the duplicate workout page which was broken with the NextJS upgrade, and a minor styling change for dark mode.