### PR TITLE
Simplify schema and delete workout logic

### DIFF
--- a/app/api/workouts/[workout]/route.ts
+++ b/app/api/workouts/[workout]/route.ts
@@ -4,10 +4,10 @@ import { workouts } from "@/db/schema";
 
 export async function DELETE(
   request: Request,
-  { params }: { params: Promise<{ id: number }> }
+  { params }: { params: Promise<{ workout: number }> }
 ) {
   try {
-    await db.delete(workouts).where(eq(workouts.id, (await params).id));
+    await db.delete(workouts).where(eq(workouts.id, (await params).workout));
     return new Response("Workout successfully deleted");
   } catch (error) {
     console.log("An error ocurred!");

--- a/app/api/workouts/[workout]/route.ts
+++ b/app/api/workouts/[workout]/route.ts
@@ -1,42 +1,13 @@
 import { eq } from "drizzle-orm";
 import { db } from "@/db/drizzle";
 import { workouts } from "@/db/schema";
-import { exercises } from "@/db/schema";
-import { sets } from "@/db/schema";
 
 export async function DELETE(
   request: Request,
-  { params }: { params: Promise<{ workout: number }> }
+  { params }: { params: Promise<{ id: number }> }
 ) {
-  const workout = (await params).workout;
   try {
-    await db.transaction(async (tx) => {
-      const result = await db.query.workouts.findMany({
-        where: (workouts, { eq }) => eq(workouts.id, workout),
-        columns: {},
-        with: {
-          exercises: {
-            columns: {
-              id: true,
-            },
-            with: {
-              sets: {
-                columns: {
-                  id: true,
-                },
-              },
-            },
-          },
-        },
-      });
-      for (const exercise of result[0].exercises) {
-        await db.delete(exercises).where(eq(exercises.id, exercise.id));
-        for (const set of exercise.sets) {
-          await db.delete(sets).where(eq(sets.id, set.id));
-        }
-      }
-      await db.delete(workouts).where(eq(workouts.id, workout));
-    });
+    await db.delete(workouts).where(eq(workouts.id, (await params).id));
     return new Response("Workout successfully deleted");
   } catch (error) {
     console.log("An error ocurred!");

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -3,7 +3,7 @@ import { text, integer, sqliteTable } from "drizzle-orm/sqlite-core";
 
 export const workouts = sqliteTable("workouts", {
   id: integer("id").primaryKey(),
-  userId: text("userId", { length: 64 }),
+  userId: text("user_id", { length: 64 }),
   name: text("name", { length: 256 }).notNull(),
   date: text("date").notNull(),
 });

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -16,7 +16,9 @@ export const exercises = sqliteTable("exercises", {
   id: integer("id").primaryKey(),
   name: text("name", { length: 256 }).notNull(),
   notes: text("notes").notNull(),
-  workoutId: integer("workout_id").notNull(),
+  workoutId: integer("workout_id")
+    .references(() => workouts.id, { onDelete: "cascade" })
+    .notNull(),
 });
 
 export const exercisesRelations = relations(exercises, ({ one, many }) => ({
@@ -31,7 +33,9 @@ export const sets = sqliteTable("sets", {
   id: integer("id").primaryKey(),
   reps: text("reps", { length: 16 }).notNull(),
   weight: text("weight", { length: 16 }).notNull(),
-  exerciseId: integer("exercise_id").notNull(),
+  exerciseId: integer("exercise_id")
+    .references(() => exercises.id, { onDelete: "cascade" })
+    .notNull(),
 });
 
 export const setsRelations = relations(sets, ({ one }) => ({


### PR DESCRIPTION
By adding a foreign key constraint to my id relations, cascading deletes can be enabled. This allows the database to handle the deletion of orphaned child exercises and sets rather than those rows being iteratively deleted. 

Benefits:
- Significantly improves performance
- Simplifies logic
- Adheres to best practices.