### PR TITLE
Clean up workout form

### DIFF
--- a/app/exercises/ExerciseSummary.tsx
+++ b/app/exercises/ExerciseSummary.tsx
@@ -67,7 +67,7 @@ export default function ExerciseSummaryComponent({
           <DialogTrigger asChild>
             <Button className="text-lg">History</Button>
           </DialogTrigger>
-          <DialogContent className="max-h-[80vh] w-5/6 rounded-md overflow-y-auto">
+          <DialogContent className="max-h-[90vh] w-11/12 rounded-md overflow-y-auto">
             <DialogHeader>
               <DialogTitle className="text-xl">
                 {exerciseSummary.name}

--- a/app/exercises/ExerciseSummary.tsx
+++ b/app/exercises/ExerciseSummary.tsx
@@ -67,7 +67,7 @@ export default function ExerciseSummaryComponent({
           <DialogTrigger asChild>
             <Button className="text-lg">History</Button>
           </DialogTrigger>
-          <DialogContent>
+          <DialogContent className="max-h-[80vh] w-5/6 rounded-md overflow-y-auto">
             <DialogHeader>
               <DialogTitle className="text-xl">
                 {exerciseSummary.name}

--- a/app/workouts/WorkoutForm.tsx
+++ b/app/workouts/WorkoutForm.tsx
@@ -45,7 +45,7 @@ export default function WorkoutForm({
 }) {
   const [showSpinner, setShowSpinner] = useState(false);
   const [exercises, setExercises] = useState([]);
-  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [popoverOpenStates, setPopoverOpenStates] = useState<boolean[]>([]);
 
   const [exerciseNameValue, setExerciseNameValue] = useState("");
 
@@ -172,15 +172,21 @@ export default function WorkoutForm({
                     render={({ field }) => (
                       <FormItem className="flex flex-col">
                         <Popover
-                          open={popoverOpen}
-                          onOpenChange={setPopoverOpen}
+                          open={popoverOpenStates[index]}
+                          onOpenChange={(isOpen) => {
+                            setPopoverOpenStates((prev) => {
+                              const newState = [...prev];
+                              newState[index] = isOpen;
+                              return newState;
+                            });
+                          }}
                         >
                           <PopoverTrigger asChild>
                             <FormControl>
                               <Button
                                 variant="outline"
                                 role="combobox"
-                                aria-expanded={popoverOpen}
+                                aria-expanded={popoverOpenStates[index]}
                                 className={cn(
                                   "w-[270px] justify-between",
                                   !field.value && "text-muted-foreground"
@@ -210,6 +216,11 @@ export default function WorkoutForm({
                                       `exercises.${index}.name`,
                                       exerciseNameValue
                                     );
+                                    setPopoverOpenStates((prev) => {
+                                      const newState = [...prev];
+                                      newState[index] = false; // Close the popover for this specific exercise
+                                      return newState;
+                                    });
                                   }
                                 }}
                               />
@@ -226,18 +237,14 @@ export default function WorkoutForm({
                                           `exercises.${index}.name`,
                                           exercise
                                         );
-                                        setPopoverOpen(false);
+                                        setPopoverOpenStates((prev) => {
+                                          const newState = [...prev];
+                                          newState[index] = false; // Close the popover for this specific exercise
+                                          return newState;
+                                        });
                                       }}
                                     >
                                       {exercise}
-                                      <Check
-                                        className={cn(
-                                          "ml-auto",
-                                          exercise === field.value
-                                            ? "opacity-100"
-                                            : "opacity-0"
-                                        )}
-                                      />
                                     </CommandItem>
                                   ))}
                                 </CommandGroup>
@@ -249,7 +256,12 @@ export default function WorkoutForm({
                     )}
                   />
                   <Trash2
-                    onClick={() => remove(index)}
+                    onClick={() => {
+                      remove(index);
+                      setPopoverOpenStates((prev) =>
+                        prev.filter((_, i) => i !== index)
+                      );
+                    }}
                     size={28}
                     className="ml-5 text-red-600 cursor-pointer"
                   ></Trash2>
@@ -280,13 +292,14 @@ export default function WorkoutForm({
               variant="secondary"
               className="mt-4 w-full"
               type="button"
-              onClick={() =>
+              onClick={() => {
                 append({
                   name: "",
                   notes: "",
                   sets: [{ weight: "", reps: "", rpe: "" }],
-                })
-              }
+                });
+                setPopoverOpenStates((prev) => [...prev, false]); // Add new popover state
+              }}
             >
               Add Exercise
             </Button>

--- a/app/workouts/WorkoutForm.tsx
+++ b/app/workouts/WorkoutForm.tsx
@@ -202,7 +202,6 @@ export default function WorkoutForm({
                               <CommandInput
                                 placeholder="Search exercise..."
                                 className="h-9"
-                                // Save current value to state
                                 onInput={(e) =>
                                   setExerciseNameValue(e.currentTarget.value)
                                 }
@@ -218,13 +217,12 @@ export default function WorkoutForm({
                                     );
                                     setPopoverOpenStates((prev) => {
                                       const newState = [...prev];
-                                      newState[index] = false; // Close the popover for this specific exercise
+                                      newState[index] = false;
                                       return newState;
                                     });
                                   }
                                 }}
                               />
-                              {/* TODO: Maybe make this shorter */}
                               <CommandList>
                                 <CommandEmpty>No exercise found.</CommandEmpty>
                                 <CommandGroup>
@@ -239,7 +237,7 @@ export default function WorkoutForm({
                                         );
                                         setPopoverOpenStates((prev) => {
                                           const newState = [...prev];
-                                          newState[index] = false; // Close the popover for this specific exercise
+                                          newState[index] = false;
                                           return newState;
                                         });
                                       }}
@@ -298,7 +296,7 @@ export default function WorkoutForm({
                   notes: "",
                   sets: [{ weight: "", reps: "", rpe: "" }],
                 });
-                setPopoverOpenStates((prev) => [...prev, false]); // Add new popover state
+                setPopoverOpenStates((prev) => [...prev, false]);
               }}
             >
               Add Exercise

--- a/app/workouts/WorkoutForm.tsx
+++ b/app/workouts/WorkoutForm.tsx
@@ -45,6 +45,7 @@ export default function WorkoutForm({
 }) {
   const [showSpinner, setShowSpinner] = useState(false);
   const [exercises, setExercises] = useState([]);
+  const [popoverOpen, setPopoverOpen] = useState(false);
 
   const [exerciseNameValue, setExerciseNameValue] = useState("");
 
@@ -170,12 +171,16 @@ export default function WorkoutForm({
                     name={`exercises.${index}.name`}
                     render={({ field }) => (
                       <FormItem className="flex flex-col">
-                        <Popover>
+                        <Popover
+                          open={popoverOpen}
+                          onOpenChange={setPopoverOpen}
+                        >
                           <PopoverTrigger asChild>
                             <FormControl>
                               <Button
                                 variant="outline"
                                 role="combobox"
+                                aria-expanded={popoverOpen}
                                 className={cn(
                                   "w-[270px] justify-between",
                                   !field.value && "text-muted-foreground"
@@ -221,7 +226,7 @@ export default function WorkoutForm({
                                           `exercises.${index}.name`,
                                           exercise
                                         );
-                                        // TODO: Gotta close command on select
+                                        setPopoverOpen(false);
                                       }}
                                     >
                                       {exercise}

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -60,7 +60,7 @@ const CommandList = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.List
     ref={ref}
-    className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+    className={cn("max-h-[200px] overflow-y-auto overflow-x-hidden", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
Clean up workout form, primarily to improve user experience on mobile devices. 

- Popover will now automatically close on selection of an exercise
- Popover exercise list height reduced
- Check marks are removed from list so it does not seem like multi select is possible

Also updated the exercise history modal so it has a limited size which previously caused an issue on mobile.