### PR TITLE
Ensure sets are only inserted if setValues is not empty

### DIFF
--- a/app/api/workouts/route.ts
+++ b/app/api/workouts/route.ts
@@ -48,7 +48,9 @@ export async function POST(request: NextRequest) {
           exerciseId: newExercise.id,
         }));
 
-        await tx.insert(set).values(setValues);
+        if (setValues.length) {
+          await tx.insert(set).values(setValues);
+        }
       }
     });
   } catch (error) {


### PR DESCRIPTION
This fix was implemented in the update workout logic, but not for create workout.