### PR TITLE
Fix issue with today's date not showing on new workouts

### DIFF
--- a/app/workouts/(form)/create/page.tsx
+++ b/app/workouts/(form)/create/page.tsx
@@ -1,14 +1,12 @@
 import WorkoutForm from "@/app/workouts/(form)/workout-form";
 
-export const dynamic = "force-dynamic";
-
 export default async function CreateWorkoutPage() {
   return (
     <WorkoutForm
       editMode={false}
       workoutId={-1}
       workoutValue={{
-        date: new Date().toLocaleDateString("en-CA"),
+        date: "",
         name: "",
         exercises: [
           { name: "", notes: "", sets: [{ weight: "", reps: "", rpe: "" }] },

--- a/app/workouts/(form)/workout-form.tsx
+++ b/app/workouts/(form)/workout-form.tsx
@@ -137,6 +137,14 @@ export default function WorkoutForm({
     name: "exercises",
   });
 
+  // Set today's date if date is empty (for create mode)
+  useEffect(() => {
+    if (!workoutValue.date) {
+      form.setValue("date", new Date().toLocaleDateString("en-CA"));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <div className="mx-auto max-w-2xl px-2 sm:px-6">
       <LoadingOverlay isLoading={isLoading} />


### PR DESCRIPTION
This was due to a caching issue where we were pulling the page which had a previous date from cache. This PR prevents that caching.