### PR TITLE
Refactor workout form seeding and save flow

### DIFF
--- a/app/workouts/(form)/create/page.tsx
+++ b/app/workouts/(form)/create/page.tsx
@@ -3,9 +3,8 @@ import WorkoutForm from "@/components/workout-form/workout-form";
 export default async function CreateWorkoutPage() {
   return (
     <WorkoutForm
-      editMode={false}
-      workoutId={-1}
-      workoutValue={{
+      persistMode="create"
+      initialValues={{
         date: "",
         durationMinutes: null,
         name: "",

--- a/app/workouts/(form)/create/page.tsx
+++ b/app/workouts/(form)/create/page.tsx
@@ -1,18 +1,10 @@
+import {
+  buildWorkoutFormSeed,
+} from "@/components/workout-form/form-model";
 import WorkoutForm from "@/components/workout-form/workout-form";
 
 export default async function CreateWorkoutPage() {
-  return (
-    <WorkoutForm
-      persistMode="create"
-      initialValues={{
-        date: "",
-        durationMinutes: null,
-        name: "",
-        notes: "",
-        exercises: [
-          { name: "", notes: "", sets: [{ weight: "", reps: "", rpe: "" }] },
-        ],
-      }}
-    />
-  );
+  const workoutSeed = await buildWorkoutFormSeed({ kind: "create" });
+
+  return <WorkoutForm {...workoutSeed} />;
 }

--- a/app/workouts/(form)/create/page.tsx
+++ b/app/workouts/(form)/create/page.tsx
@@ -13,6 +13,6 @@ export default async function CreateWorkoutPage() {
           { name: "", notes: "", sets: [{ weight: "", reps: "", rpe: "" }] },
         ],
       }}
-    ></WorkoutForm>
+    />
   );
 }

--- a/app/workouts/(form)/duplicate/[id]/page.tsx
+++ b/app/workouts/(form)/duplicate/[id]/page.tsx
@@ -1,29 +1,8 @@
-import { auth } from "@clerk/nextjs/server";
-import { db } from "@/db/drizzle";
-import { Workout } from "@/lib/types";
-import { buildDuplicateWorkoutFormSeed } from "@/components/workout-form/form-model";
+import {
+  buildWorkoutFormSeed,
+} from "@/components/workout-form/form-model";
 import WorkoutForm from "@/components/workout-form/workout-form";
 import WorkoutNotFound from "@/components/workout-form/workout-not-found";
-
-async function getWorkout(id: number) {
-  const { userId, redirectToSignIn } = await auth();
-  if (!userId) redirectToSignIn();
-
-  const data: Workout | undefined = await db.query.workout.findFirst({
-    where: (workout, { eq, and }) =>
-      and(eq(workout.id, id), eq(workout.userId, userId!)),
-    with: {
-      exercises: {
-        with: {
-          sets: {
-            orderBy: (sets, { asc }) => [asc(sets.id)],
-          },
-        },
-      },
-    },
-  });
-  return data;
-}
 
 export default async function DuplicateWorkoutPage({
   params,
@@ -32,15 +11,18 @@ export default async function DuplicateWorkoutPage({
 }) {
   const { id } = await params;
 
-  if (isNaN(+id)) return <WorkoutNotFound />;
-
-  const workout = await getWorkout(+id);
-
-  if (!workout) {
+  if (isNaN(+id)) {
     return <WorkoutNotFound />;
   }
 
-  const workoutSeed = buildDuplicateWorkoutFormSeed(workout);
+  const workoutSeed = await buildWorkoutFormSeed({
+    kind: "duplicate",
+    workoutId: +id,
+  });
+
+  if (!workoutSeed) {
+    return <WorkoutNotFound />;
+  }
 
   return <WorkoutForm {...workoutSeed} />;
 }

--- a/app/workouts/(form)/duplicate/[id]/page.tsx
+++ b/app/workouts/(form)/duplicate/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { db } from "@/db/drizzle";
 import { Workout, TWorkoutFormSchema } from "@/lib/types";
+import { toTemplateValuesByExerciseName } from "@/components/workout-form/form-model";
 import WorkoutForm from "@/components/workout-form/workout-form";
 import WorkoutNotFound from "@/components/workout-form/workout-not-found";
 
@@ -87,10 +88,11 @@ export default async function DuplicateWorkoutPage({
 
   return (
     <WorkoutForm
-      workoutValue={workout}
-      editMode={false}
-      workoutId={-1}
-      placeholderValues={workoutTemplate.exercises}
+      initialValues={workout}
+      persistMode="create"
+      templateValuesByExerciseName={toTemplateValuesByExerciseName(
+        workoutTemplate.exercises,
+      )}
     ></WorkoutForm>
   );
 }

--- a/app/workouts/(form)/duplicate/[id]/page.tsx
+++ b/app/workouts/(form)/duplicate/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { db } from "@/db/drizzle";
-import { Workout, TWorkoutFormSchema } from "@/lib/types";
-import { toTemplateValuesByExerciseName } from "@/components/workout-form/form-model";
+import { Workout } from "@/lib/types";
+import { buildDuplicateWorkoutFormSeed } from "@/components/workout-form/form-model";
 import WorkoutForm from "@/components/workout-form/workout-form";
 import WorkoutNotFound from "@/components/workout-form/workout-not-found";
 
@@ -22,52 +22,8 @@ async function getWorkout(id: number) {
       },
     },
   });
-  return convertToFormType(data);
+  return data;
 }
-
-/**
- * Populates placeholder values for a template workout
- * @param workout the workout to populate placeholder values with
- * @returns a form poulated with placeholder values
- */
-const convertToFormType = (
-  workout: Workout | undefined,
-): TWorkoutFormSchema | undefined => {
-  if (!workout) return undefined;
-  const convertedWorkout: TWorkoutFormSchema = {
-    name: `Copy of ${workout.name}`,
-    date: new Date().toISOString().substring(0, 10),
-    notes: "",
-    durationMinutes: null,
-    exercises: workout.exercises.map((exercise) => ({
-      name: exercise.name,
-      notes: "",
-      sets: exercise.sets.map((set) => ({
-        reps: set.reps,
-        weight: set.weight,
-        rpe: set.rpe,
-      })),
-    })),
-  };
-
-  return convertedWorkout;
-};
-
-const zeroWorkout = (workout?: TWorkoutFormSchema) => {
-  if (!workout) return undefined;
-
-  const zeroedWorkout: TWorkoutFormSchema = JSON.parse(JSON.stringify(workout));
-
-  zeroedWorkout.exercises.forEach((exercise) => {
-    exercise.sets.forEach((set) => {
-      set.reps = "";
-      set.weight = "";
-      set.rpe = "";
-    });
-  });
-
-  return zeroedWorkout;
-};
 
 export default async function DuplicateWorkoutPage({
   params,
@@ -76,23 +32,15 @@ export default async function DuplicateWorkoutPage({
 }) {
   const { id } = await params;
 
-  if (isNaN(+id)) return <WorkoutNotFound></WorkoutNotFound>;
+  if (isNaN(+id)) return <WorkoutNotFound />;
 
-  const workoutTemplate = await getWorkout(+id);
+  const workout = await getWorkout(+id);
 
-  const workout = zeroWorkout(workoutTemplate);
-
-  if (!workoutTemplate || !workout) {
-    return <WorkoutNotFound></WorkoutNotFound>;
+  if (!workout) {
+    return <WorkoutNotFound />;
   }
 
-  return (
-    <WorkoutForm
-      initialValues={workout}
-      persistMode="create"
-      templateValuesByExerciseName={toTemplateValuesByExerciseName(
-        workoutTemplate.exercises,
-      )}
-    ></WorkoutForm>
-  );
+  const workoutSeed = buildDuplicateWorkoutFormSeed(workout);
+
+  return <WorkoutForm {...workoutSeed} />;
 }

--- a/app/workouts/(form)/edit/[id]/page.tsx
+++ b/app/workouts/(form)/edit/[id]/page.tsx
@@ -1,51 +1,8 @@
-import { auth } from "@clerk/nextjs/server";
-import { db } from "@/db/drizzle";
-import { Workout, TWorkoutFormSchema } from "@/lib/types";
+import {
+  buildWorkoutFormSeed,
+} from "@/components/workout-form/form-model";
 import WorkoutForm from "@/components/workout-form/workout-form";
 import WorkoutNotFound from "@/components/workout-form/workout-not-found";
-
-async function getWorkout(id: number) {
-  const { userId, redirectToSignIn } = await auth();
-  if (!userId) redirectToSignIn();
-
-  const data: Workout | undefined = await db.query.workout.findFirst({
-    where: (workout, { eq, and }) =>
-      and(eq(workout.id, id), eq(workout.userId, userId!)),
-    with: {
-      exercises: {
-        with: {
-          sets: {
-            orderBy: (sets, { asc }) => [asc(sets.id)],
-          },
-        },
-      },
-    },
-  });
-  return convertToFormType(data);
-}
-
-const convertToFormType = (
-  workout: Workout | undefined,
-): TWorkoutFormSchema | undefined => {
-  if (!workout) return undefined;
-  const convertedWorkout: TWorkoutFormSchema = {
-    name: workout.name,
-    date: workout.date,
-    notes: workout.notes,
-    durationMinutes: workout.durationMinutes,
-    exercises: workout.exercises.map((exercise) => ({
-      name: exercise.name,
-      notes: exercise.notes,
-      sets: exercise.sets.map((set) => ({
-        reps: set.reps,
-        weight: set.weight,
-        rpe: set.rpe,
-      })),
-    })),
-  };
-
-  return convertedWorkout;
-};
 
 export default async function EditWorkoutPage({
   params,
@@ -54,15 +11,18 @@ export default async function EditWorkoutPage({
 }) {
   const { id } = await params;
 
-  if (isNaN(+id)) return <WorkoutNotFound />;
-
-  const workout = await getWorkout(+id);
-
-  if (!workout) {
+  if (isNaN(+id)) {
     return <WorkoutNotFound />;
   }
 
-  return (
-    <WorkoutForm initialValues={workout} persistMode="update" workoutId={+id} />
-  );
+  const workoutSeed = await buildWorkoutFormSeed({
+    kind: "edit",
+    workoutId: +id,
+  });
+
+  if (!workoutSeed) {
+    return <WorkoutNotFound />;
+  }
+
+  return <WorkoutForm {...workoutSeed} />;
 }

--- a/app/workouts/(form)/edit/[id]/page.tsx
+++ b/app/workouts/(form)/edit/[id]/page.tsx
@@ -64,8 +64,8 @@ export default async function EditWorkoutPage({
 
   return (
     <WorkoutForm
-      workoutValue={workout}
-      editMode={true}
+      initialValues={workout}
+      persistMode="update"
       workoutId={+id}
     ></WorkoutForm>
   );

--- a/app/workouts/(form)/edit/[id]/page.tsx
+++ b/app/workouts/(form)/edit/[id]/page.tsx
@@ -54,19 +54,15 @@ export default async function EditWorkoutPage({
 }) {
   const { id } = await params;
 
-  if (isNaN(+id)) return <WorkoutNotFound></WorkoutNotFound>;
+  if (isNaN(+id)) return <WorkoutNotFound />;
 
   const workout = await getWorkout(+id);
 
   if (!workout) {
-    return <WorkoutNotFound></WorkoutNotFound>;
+    return <WorkoutNotFound />;
   }
 
   return (
-    <WorkoutForm
-      initialValues={workout}
-      persistMode="update"
-      workoutId={+id}
-    ></WorkoutForm>
+    <WorkoutForm initialValues={workout} persistMode="update" workoutId={+id} />
   );
 }

--- a/app/workouts/page.tsx
+++ b/app/workouts/page.tsx
@@ -47,7 +47,7 @@ export default async function WorkoutsPage() {
           <span>Create Workout</span>
         </Link>
       </Button>
-      <Workouts workouts={workouts}></Workouts>
+      <Workouts workouts={workouts} />
     </div>
   );
 }

--- a/components/exercise/exercises-ui.tsx
+++ b/components/exercise/exercises-ui.tsx
@@ -109,7 +109,7 @@ export default function ExercisesUI({
               <ExerciseSummaryComponent
                 exerciseSummary={exerciseSummary}
                 key={exerciseSummary.name}
-              ></ExerciseSummaryComponent>
+              />
             </AccordionContent>
           </AccordionItem>
         ))}

--- a/components/workout-form/exercise-actions-menu.tsx
+++ b/components/workout-form/exercise-actions-menu.tsx
@@ -17,7 +17,7 @@ import {
 
 interface ExerciseActionsMenuProps {
   exerciseName: string;
-  workoutId: number;
+  workoutId?: number;
   onDelete: () => void;
   onMoveUp: () => void;
   onMoveDown: () => void;

--- a/components/workout-form/exercise-item.tsx
+++ b/components/workout-form/exercise-item.tsx
@@ -8,7 +8,7 @@ import FormSets from "@/components/workout-form/form-sets";
 import type {
   ExerciseTemplateValues,
   WorkoutDraft,
-} from "@/components/workout-form/form-model";
+} from "@/components/workout-form/form-types";
 
 interface ExerciseItemProps {
   index: number;

--- a/components/workout-form/exercise-item.tsx
+++ b/components/workout-form/exercise-item.tsx
@@ -5,12 +5,15 @@ import { Field, FieldError } from "@/components/ui/field";
 import ExerciseSelector from "@/components/workout-form/exercise-selector";
 import ExerciseActionsMenu from "@/components/workout-form/exercise-actions-menu";
 import FormSets from "@/components/workout-form/form-sets";
-import { TWorkoutFormSchema, ExerciseThin } from "@/lib/types";
+import type {
+  ExerciseTemplateValues,
+  WorkoutDraft,
+} from "@/components/workout-form/form-model";
 
 interface ExerciseItemProps {
   index: number;
-  control: Control<TWorkoutFormSchema>;
-  getValues: UseFormGetValues<TWorkoutFormSchema>;
+  control: Control<WorkoutDraft>;
+  getValues: UseFormGetValues<WorkoutDraft>;
   exercises: string[];
   exerciseName: string;
   onRemove: () => void;
@@ -18,8 +21,8 @@ interface ExerciseItemProps {
   onMoveDown: () => void;
   isFirst: boolean;
   isLast: boolean;
-  workoutId: number;
-  placeholderValues?: ExerciseThin[];
+  workoutId?: number;
+  templateExercise?: ExerciseTemplateValues;
 }
 
 export default function ExerciseItem({
@@ -34,7 +37,7 @@ export default function ExerciseItem({
   isFirst,
   isLast,
   workoutId,
-  placeholderValues,
+  templateExercise,
 }: ExerciseItemProps) {
   return (
     <div className="space-y-4 rounded-lg border p-3">
@@ -67,11 +70,10 @@ export default function ExerciseItem({
       </div>
 
       <FormSets
-        exerciseName={exerciseName}
         exerciseIndex={index}
         control={control}
         getValues={getValues}
-        placeholderValues={placeholderValues}
+        templateExercise={templateExercise}
       />
 
       <Controller

--- a/components/workout-form/exercise-selector.tsx
+++ b/components/workout-form/exercise-selector.tsx
@@ -30,6 +30,7 @@ export default function ExerciseSelector({
 }: ExerciseSelectorProps) {
   const [open, setOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
+  const displayValue = value || "Select exercise";
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -38,12 +39,13 @@ export default function ExerciseSelector({
           variant="outline"
           role="combobox"
           aria-expanded={open}
+          title={displayValue}
           className={cn(
-            "bg-background/50 hover:bg-background/80 h-10 w-full flex-1 justify-between text-base transition-colors sm:h-11",
+            "bg-background/50 hover:bg-background/80 grid h-10 w-full flex-1 grid-cols-[minmax(0,1fr)_auto] text-base transition-colors sm:h-11",
             !value && "text-muted-foreground",
           )}
         >
-          <span className="truncate">{value ? value : "Select exercise"}</span>
+          <span className="truncate text-left">{displayValue}</span>
           <ChevronsUpDown />
         </Button>
       </PopoverTrigger>

--- a/components/workout-form/exercise-selector.tsx
+++ b/components/workout-form/exercise-selector.tsx
@@ -30,7 +30,6 @@ export default function ExerciseSelector({
 }: ExerciseSelectorProps) {
   const [open, setOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
-  const displayValue = value || "Select exercise";
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -39,13 +38,12 @@ export default function ExerciseSelector({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          title={displayValue}
           className={cn(
-            "bg-background/50 hover:bg-background/80 grid h-10 w-full flex-1 grid-cols-[minmax(0,1fr)_auto] text-base transition-colors sm:h-11",
+            "bg-background/50 hover:bg-background/80 h-10 w-full flex-1 justify-between text-base transition-colors sm:h-11",
             !value && "text-muted-foreground",
           )}
         >
-          <span className="truncate text-left">{displayValue}</span>
+          <span className="truncate">{value ? value : "Select exercise"}</span>
           <ChevronsUpDown />
         </Button>
       </PopoverTrigger>

--- a/components/workout-form/form-model.ts
+++ b/components/workout-form/form-model.ts
@@ -1,14 +1,47 @@
+import "server-only";
+
+import { auth } from "@clerk/nextjs/server";
+import { db } from "@/db/drizzle";
 import type { Workout } from "@/lib/types";
 import type {
   CreateWorkoutFormSeed,
   ExerciseTemplateValues,
+  UpdateWorkoutFormProps,
   WorkoutDraft,
+  WorkoutFormSeed,
+  WorkoutFormSeedMode,
 } from "@/components/workout-form/form-types";
 
-function convertToFormType(workout: Workout): WorkoutDraft {
+function cloneWorkoutDraft(values: WorkoutDraft): WorkoutDraft {
+  return structuredClone(values);
+}
+
+export function getWorkoutFormTodayDate(): string {
+  return new Date().toLocaleDateString("en-CA");
+}
+
+function toWorkoutDraft(workout: Workout): WorkoutDraft {
+  return {
+    name: workout.name,
+    date: workout.date,
+    notes: workout.notes,
+    durationMinutes: workout.durationMinutes,
+    exercises: workout.exercises.map((exercise) => ({
+      name: exercise.name,
+      notes: exercise.notes,
+      sets: exercise.sets.map((set) => ({
+        reps: set.reps,
+        weight: set.weight,
+        rpe: set.rpe,
+      })),
+    })),
+  };
+}
+
+function toDuplicateWorkoutDraft(workout: Workout): WorkoutDraft {
   return {
     name: `Copy of ${workout.name}`,
-    date: new Date().toISOString().substring(0, 10),
+    date: getWorkoutFormTodayDate(),
     notes: "",
     durationMinutes: null,
     exercises: workout.exercises.map((exercise) => ({
@@ -23,10 +56,11 @@ function convertToFormType(workout: Workout): WorkoutDraft {
   };
 }
 
-function zeroWorkout(workout: WorkoutDraft): WorkoutDraft {
-  const zeroedWorkout = structuredClone(workout);
+function zeroWorkoutSetValues(workout: WorkoutDraft): WorkoutDraft {
+  const zeroedWorkout = cloneWorkoutDraft(workout);
 
   zeroedWorkout.exercises.forEach((exercise) => {
+    exercise.notes = "";
     exercise.sets.forEach((set) => {
       set.reps = "";
       set.weight = "";
@@ -52,16 +86,109 @@ function toTemplateValuesByExerciseName(
   return templateValuesByExerciseName;
 }
 
+async function getOwnedWorkout(workoutId: number): Promise<Workout | null> {
+  const { userId, redirectToSignIn } = await auth();
+
+  if (!userId) {
+    redirectToSignIn();
+  }
+
+  const workout = await db.query.workout.findFirst({
+    where: (workout, { eq, and }) =>
+      and(eq(workout.id, workoutId), eq(workout.userId, userId!)),
+    with: {
+      exercises: {
+        with: {
+          sets: {
+            orderBy: (sets, { asc }) => [asc(sets.id)],
+          },
+        },
+      },
+    },
+  });
+
+  return workout ?? null;
+}
+
+export function buildBlankWorkoutFormSeed(): CreateWorkoutFormSeed {
+  return {
+    persistMode: "create",
+    initialValues: {
+      name: "",
+      date: getWorkoutFormTodayDate(),
+      notes: "",
+      durationMinutes: null,
+      exercises: [
+        {
+          name: "",
+          notes: "",
+          sets: [{ weight: "", reps: "", rpe: "" }],
+        },
+      ],
+    },
+  };
+}
+
+export function buildEditWorkoutFormSeed(
+  workout: Workout,
+): UpdateWorkoutFormProps {
+  return {
+    persistMode: "update",
+    workoutId: workout.id,
+    initialValues: toWorkoutDraft(workout),
+  };
+}
+
 export function buildDuplicateWorkoutFormSeed(
   workout: Workout,
 ): CreateWorkoutFormSeed {
-  const workoutTemplate = convertToFormType(workout);
+  const workoutTemplate = toDuplicateWorkoutDraft(workout);
 
   return {
     persistMode: "create",
-    initialValues: zeroWorkout(workoutTemplate),
+    initialValues: zeroWorkoutSetValues(workoutTemplate),
     templateValuesByExerciseName: toTemplateValuesByExerciseName(
       workoutTemplate.exercises,
     ),
   };
+}
+
+export function buildWorkoutFormSeed(input: {
+  kind: "create";
+  workoutId?: number;
+}): Promise<CreateWorkoutFormSeed>;
+export function buildWorkoutFormSeed(input: {
+  kind: "edit";
+  workoutId: number;
+}): Promise<UpdateWorkoutFormProps | null>;
+export function buildWorkoutFormSeed(input: {
+  kind: "duplicate";
+  workoutId: number;
+}): Promise<CreateWorkoutFormSeed | null>;
+export async function buildWorkoutFormSeed({
+  kind,
+  workoutId,
+}: {
+  kind: WorkoutFormSeedMode;
+  workoutId?: number;
+}): Promise<WorkoutFormSeed | null> {
+  if (kind === "create") {
+    return buildBlankWorkoutFormSeed();
+  }
+
+  if (workoutId == null) {
+    throw new Error(`buildWorkoutFormSeed requires workoutId for ${kind}`);
+  }
+
+  const workout = await getOwnedWorkout(workoutId);
+
+  if (!workout) {
+    return null;
+  }
+
+  if (kind === "edit") {
+    return buildEditWorkoutFormSeed(workout);
+  }
+
+  return buildDuplicateWorkoutFormSeed(workout);
 }

--- a/components/workout-form/form-model.ts
+++ b/components/workout-form/form-model.ts
@@ -1,4 +1,4 @@
-import type { ExerciseThin, TWorkoutFormSchema } from "@/lib/types";
+import type { ExerciseThin, TWorkoutFormSchema, Workout } from "@/lib/types";
 
 export type PersistMode = "create" | "update";
 
@@ -13,15 +13,49 @@ export type WorkoutFormSeed = {
   templateValuesByExerciseName?: Record<string, ExerciseTemplateValues>;
 };
 
+export type CreateWorkoutFormSeed = Omit<WorkoutFormSeed, "persistMode"> & {
+  persistMode: "create";
+};
+
 export type SaveState = "idle" | "saving" | "saved" | "failed";
 
-export function toTemplateValuesByExerciseName(
+function convertToFormType(workout: Workout): WorkoutDraft {
+  return {
+    name: `Copy of ${workout.name}`,
+    date: new Date().toISOString().substring(0, 10),
+    notes: "",
+    durationMinutes: null,
+    exercises: workout.exercises.map((exercise) => ({
+      name: exercise.name,
+      notes: "",
+      sets: exercise.sets.map((set) => ({
+        reps: set.reps,
+        weight: set.weight,
+        rpe: set.rpe,
+      })),
+    })),
+  };
+}
+
+function zeroWorkout(workout: WorkoutDraft): WorkoutDraft {
+  const zeroedWorkout = structuredClone(workout);
+
+  zeroedWorkout.exercises.forEach((exercise) => {
+    exercise.sets.forEach((set) => {
+      set.reps = "";
+      set.weight = "";
+      set.rpe = "";
+    });
+  });
+
+  return zeroedWorkout;
+}
+
+function toTemplateValuesByExerciseName(
   exercises: ExerciseTemplateValues[],
 ): Record<string, ExerciseTemplateValues> {
   const templateValuesByExerciseName: Record<string, ExerciseTemplateValues> =
     {};
-
-  // TODO: Check if some of the logic from the duplicate page can be moved in here
 
   for (const exercise of exercises) {
     if (!(exercise.name in templateValuesByExerciseName)) {
@@ -30,4 +64,18 @@ export function toTemplateValuesByExerciseName(
   }
 
   return templateValuesByExerciseName;
+}
+
+export function buildDuplicateWorkoutFormSeed(
+  workout: Workout,
+): CreateWorkoutFormSeed {
+  const workoutTemplate = convertToFormType(workout);
+
+  return {
+    persistMode: "create",
+    initialValues: zeroWorkout(workoutTemplate),
+    templateValuesByExerciseName: toTemplateValuesByExerciseName(
+      workoutTemplate.exercises,
+    ),
+  };
 }

--- a/components/workout-form/form-model.ts
+++ b/components/workout-form/form-model.ts
@@ -1,23 +1,9 @@
-import type { ExerciseThin, TWorkoutFormSchema, Workout } from "@/lib/types";
-
-export type PersistMode = "create" | "update";
-
-export type WorkoutDraft = TWorkoutFormSchema;
-
-export type ExerciseTemplateValues = ExerciseThin;
-
-export type WorkoutFormSeed = {
-  initialValues: WorkoutDraft;
-  persistMode: PersistMode;
-  workoutId?: number;
-  templateValuesByExerciseName?: Record<string, ExerciseTemplateValues>;
-};
-
-export type CreateWorkoutFormSeed = Omit<WorkoutFormSeed, "persistMode"> & {
-  persistMode: "create";
-};
-
-export type SaveState = "idle" | "saving" | "saved" | "failed";
+import type { Workout } from "@/lib/types";
+import type {
+  CreateWorkoutFormSeed,
+  ExerciseTemplateValues,
+  WorkoutDraft,
+} from "@/components/workout-form/form-types";
 
 function convertToFormType(workout: Workout): WorkoutDraft {
   return {

--- a/components/workout-form/form-model.ts
+++ b/components/workout-form/form-model.ts
@@ -1,0 +1,33 @@
+import type { ExerciseThin, TWorkoutFormSchema } from "@/lib/types";
+
+export type PersistMode = "create" | "update";
+
+export type WorkoutDraft = TWorkoutFormSchema;
+
+export type ExerciseTemplateValues = ExerciseThin;
+
+export type WorkoutFormSeed = {
+  initialValues: WorkoutDraft;
+  persistMode: PersistMode;
+  workoutId?: number;
+  templateValuesByExerciseName?: Record<string, ExerciseTemplateValues>;
+};
+
+export type SaveState = "idle" | "saving" | "saved" | "failed";
+
+export function toTemplateValuesByExerciseName(
+  exercises: ExerciseTemplateValues[],
+): Record<string, ExerciseTemplateValues> {
+  const templateValuesByExerciseName: Record<string, ExerciseTemplateValues> =
+    {};
+
+  // TODO: Check if some of the logic from the duplicate page can be moved in here
+
+  for (const exercise of exercises) {
+    if (!(exercise.name in templateValuesByExerciseName)) {
+      templateValuesByExerciseName[exercise.name] = exercise;
+    }
+  }
+
+  return templateValuesByExerciseName;
+}

--- a/components/workout-form/form-sets.tsx
+++ b/components/workout-form/form-sets.tsx
@@ -1,25 +1,26 @@
 import { Input } from "@/components/ui/input";
 import { useFieldArray, Controller } from "react-hook-form";
 import { Control, UseFormGetValues } from "react-hook-form";
-import { ExerciseThin, TWorkoutFormSchema } from "@/lib/types";
 import { FieldLegend, FieldSet } from "@/components/ui/field";
 import { Button } from "@/components/ui/button";
 import { Trash2 } from "lucide-react";
+import type {
+  ExerciseTemplateValues,
+  WorkoutDraft,
+} from "@/components/workout-form/form-model";
 
 interface FormSetsProps {
-  exerciseName: string;
   exerciseIndex: number;
-  control: Control<TWorkoutFormSchema>;
-  getValues: UseFormGetValues<TWorkoutFormSchema>;
-  placeholderValues?: ExerciseThin[];
+  control: Control<WorkoutDraft>;
+  getValues: UseFormGetValues<WorkoutDraft>;
+  templateExercise?: ExerciseTemplateValues;
 }
 
 export default function FormSets({
-  exerciseName,
   exerciseIndex,
   control,
   getValues,
-  placeholderValues,
+  templateExercise,
 }: FormSetsProps) {
   const { fields, remove, append } = useFieldArray({
     name: `exercises.${exerciseIndex}.sets`,
@@ -38,11 +39,7 @@ export default function FormSets({
               <Input
                 {...field}
                 id={field.name}
-                placeholder={
-                  placeholderValues?.find((x) => x.name === exerciseName)?.sets[
-                    index
-                  ]?.weight ?? "Weight"
-                }
+                placeholder={templateExercise?.sets[index]?.weight ?? "Weight"}
                 inputMode="decimal"
                 className="w-20 text-[16px]"
               />
@@ -55,11 +52,7 @@ export default function FormSets({
               <Input
                 {...field}
                 id={field.name}
-                placeholder={
-                  placeholderValues?.find((x) => x.name === exerciseName)?.sets[
-                    index
-                  ]?.reps ?? "Reps"
-                }
+                placeholder={templateExercise?.sets[index]?.reps ?? "Reps"}
                 inputMode="decimal"
                 className="w-16 text-[16px]"
               />
@@ -72,11 +65,7 @@ export default function FormSets({
               <Input
                 {...field}
                 id={field.name}
-                placeholder={
-                  placeholderValues?.find((x) => x.name === exerciseName)?.sets[
-                    index
-                  ]?.rpe ?? "RPE"
-                }
+                placeholder={templateExercise?.sets[index]?.rpe ?? "RPE"}
                 inputMode="decimal"
                 className="w-20 text-[16px]"
               />

--- a/components/workout-form/form-sets.tsx
+++ b/components/workout-form/form-sets.tsx
@@ -7,7 +7,7 @@ import { Trash2 } from "lucide-react";
 import type {
   ExerciseTemplateValues,
   WorkoutDraft,
-} from "@/components/workout-form/form-model";
+} from "@/components/workout-form/form-types";
 
 interface FormSetsProps {
   exerciseIndex: number;

--- a/components/workout-form/form-types.ts
+++ b/components/workout-form/form-types.ts
@@ -1,0 +1,37 @@
+import type { ExerciseThin, TWorkoutFormSchema } from "@/lib/types";
+
+export type PersistMode = "create" | "update";
+
+export type WorkoutDraft = TWorkoutFormSchema;
+
+export type ExerciseTemplateValues = ExerciseThin;
+
+export type WorkoutFormSeed = {
+  initialValues: WorkoutDraft;
+  persistMode: PersistMode;
+  workoutId?: number;
+  templateValuesByExerciseName?: Record<string, ExerciseTemplateValues>;
+};
+
+export type CreateWorkoutFormSeed = Omit<WorkoutFormSeed, "persistMode"> & {
+  persistMode: "create";
+};
+
+export type SaveState = "idle" | "saving" | "saved" | "failed";
+
+export type CreateWorkoutFormProps = {
+  initialValues: WorkoutDraft;
+  persistMode: "create";
+  templateValuesByExerciseName?: Record<string, ExerciseTemplateValues>;
+};
+
+export type UpdateWorkoutFormProps = {
+  initialValues: WorkoutDraft;
+  persistMode: "update";
+  workoutId: number;
+  templateValuesByExerciseName?: Record<string, ExerciseTemplateValues>;
+};
+
+export type WorkoutFormProps =
+  | CreateWorkoutFormProps
+  | UpdateWorkoutFormProps;

--- a/components/workout-form/form-types.ts
+++ b/components/workout-form/form-types.ts
@@ -1,6 +1,7 @@
 import type { ExerciseThin, TWorkoutFormSchema } from "@/lib/types";
 
 export type PersistMode = "create" | "update";
+export type WorkoutFormSeedMode = "create" | "edit" | "duplicate";
 
 export type WorkoutDraft = TWorkoutFormSchema;
 

--- a/components/workout-form/save-workout.ts
+++ b/components/workout-form/save-workout.ts
@@ -1,0 +1,126 @@
+"use client";
+
+import { toast } from "sonner";
+import type {
+  PersistMode,
+  WorkoutDraft,
+} from "@/components/workout-form/form-types";
+
+export type SaveWorkoutInput = {
+  persistMode: PersistMode;
+  values: WorkoutDraft;
+  workoutId?: number;
+};
+
+export type SaveWorkoutResult =
+  | { ok: true; workoutId: number }
+  | { ok: false };
+
+type SaveRequestConfig = {
+  url: string;
+  method: "POST" | "PATCH";
+  failureMessage: string;
+  errorContext: string;
+};
+
+async function performSaveRequest(
+  values: WorkoutDraft,
+  { url, method, failureMessage, errorContext }: SaveRequestConfig,
+): Promise<Response | null> {
+  try {
+    const response = await fetch(url, {
+      method,
+      body: JSON.stringify(values),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      console.error(`${errorContext}: request failed`, {
+        method,
+        url,
+        status: response.status,
+      });
+      toast.error(failureMessage);
+      return null;
+    }
+
+    return response;
+  } catch (error) {
+    console.error(`${errorContext}: request threw`, error);
+    toast.error(failureMessage);
+    return null;
+  }
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value > 0
+  );
+}
+
+export async function saveWorkout({
+  persistMode,
+  values,
+  workoutId,
+}: SaveWorkoutInput): Promise<SaveWorkoutResult> {
+  if (persistMode === "create") {
+    const response = await performSaveRequest(values, {
+      url: "/api/workouts",
+      method: "POST",
+      failureMessage: "Failed to create workout",
+      errorContext: "saveWorkout(create)",
+    });
+
+    if (!response) {
+      return { ok: false };
+    }
+
+    try {
+      const data: unknown = await response.json();
+
+      if (
+        typeof data !== "object" ||
+        data === null ||
+        !("workoutId" in data) ||
+        !isPositiveInteger(data.workoutId)
+      ) {
+        console.error("saveWorkout(create): invalid response payload", data);
+        toast.error("Failed to create workout");
+        return { ok: false };
+      }
+
+      return {
+        ok: true,
+        workoutId: data.workoutId,
+      };
+    } catch (error) {
+      console.error("saveWorkout(create): failed to parse response", error);
+      toast.error("Failed to create workout");
+      return { ok: false };
+    }
+  }
+
+  if (workoutId == null) {
+    throw new Error("saveWorkout requires workoutId in update mode");
+  }
+
+  const response = await performSaveRequest(values, {
+    url: `/api/workouts/${workoutId}`,
+    method: "PATCH",
+    failureMessage: "Failed to save workout",
+    errorContext: "saveWorkout(update)",
+  });
+
+  if (!response) {
+    return { ok: false };
+  }
+
+  return {
+    ok: true,
+    workoutId,
+  };
+}

--- a/components/workout-form/workout-form.tsx
+++ b/components/workout-form/workout-form.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Controller, useForm, useFieldArray, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/components/ui/button";
@@ -10,10 +10,10 @@ import WorkoutFormActionHeader, {
 } from "@/components/workout-form/workout-form-action-header";
 import { workoutFormSchema } from "@/lib/types";
 import type {
-  ExerciseTemplateValues,
   PersistMode,
   WorkoutDraft,
   WorkoutFormProps,
+  WorkoutFormSeed,
 } from "@/components/workout-form/form-types";
 import {
   Field,
@@ -63,32 +63,63 @@ const getSaveStatus = ({
   return "saved";
 };
 
-type WorkoutFormSession = {
-  persistMode: PersistMode;
-  workoutId?: number;
-  templateValuesByExerciseName?: Record<string, ExerciseTemplateValues>;
+type WorkoutFormSession = Omit<WorkoutFormSeed, "initialValues">;
+
+type LocalCreatePromotion = {
+  sourceSeedKey: string;
+  workoutId: number;
 };
 
-export default function WorkoutForm({
+function getWorkoutFormSeedKey({
   initialValues,
-  persistMode,
-  templateValuesByExerciseName,
-  ...props
-}: WorkoutFormProps) {
-  const [hasSaveFailed, setHasSaveFailed] = useState(false);
+  formSession,
+}: {
+  initialValues: WorkoutDraft;
+  formSession: WorkoutFormSession;
+}): string {
+  return JSON.stringify({
+    initialValues,
+    persistMode: formSession.persistMode,
+    workoutId: formSession.workoutId,
+    templateValuesByExerciseName: formSession.templateValuesByExerciseName,
+  });
+}
+
+export default function WorkoutForm(props: WorkoutFormProps) {
+  const { initialValues, persistMode, templateValuesByExerciseName } = props;
+  const workoutId = "workoutId" in props ? props.workoutId : undefined;
+  const [failedSaveSeedKey, setFailedSaveSeedKey] = useState<string | null>(
+    null,
+  );
+  const [localCreatePromotion, setLocalCreatePromotion] =
+    useState<LocalCreatePromotion | null>(null);
   const [exercises, setExercises] = useState<string[]>([]);
-  const [formSession, setFormSession] = useState<WorkoutFormSession>(() => ({
-    persistMode,
-    workoutId: "workoutId" in props ? props.workoutId : undefined,
-    templateValuesByExerciseName,
-  }));
-  const normalizedWorkoutValue = useMemo(
+  const normalizedInitialValues = useMemo(
     () => normalizeWorkoutForm(initialValues),
     [initialValues],
   );
+  const incomingFormSession: WorkoutFormSession = {
+    persistMode,
+    workoutId,
+    templateValuesByExerciseName,
+  };
+  const incomingSeedKey = getWorkoutFormSeedKey({
+    initialValues: normalizedInitialValues,
+    formSession: incomingFormSession,
+  });
+  const formSession: WorkoutFormSession =
+    localCreatePromotion?.sourceSeedKey === incomingSeedKey
+      ? {
+          ...incomingFormSession,
+          persistMode: "update",
+          workoutId: localCreatePromotion.workoutId,
+        }
+      : incomingFormSession;
+  const hasSaveFailed = failedSaveSeedKey === incomingSeedKey;
+  const appliedSeedKeyRef = useRef(incomingSeedKey);
   const form = useForm<WorkoutDraft>({
     resolver: zodResolver(workoutFormSchema),
-    values: normalizedWorkoutValue,
+    defaultValues: normalizedInitialValues,
   });
   const {
     control,
@@ -123,6 +154,15 @@ export default function WorkoutForm({
   }, []);
 
   useEffect(() => {
+    if (incomingSeedKey === appliedSeedKeyRef.current) {
+      return;
+    }
+
+    appliedSeedKeyRef.current = incomingSeedKey;
+    reset(normalizedInitialValues);
+  }, [incomingSeedKey, normalizedInitialValues, reset]);
+
+  useEffect(() => {
     if (!hasSaveFailed) {
       return;
     }
@@ -134,7 +174,7 @@ export default function WorkoutForm({
           return;
         }
 
-        setHasSaveFailed(false);
+        setFailedSaveSeedKey(null);
         unsubscribe();
       },
     });
@@ -146,7 +186,7 @@ export default function WorkoutForm({
 
   const onSubmit = async (values: WorkoutDraft) => {
     const submittedSnapshot = cloneWorkoutForm(values);
-    setHasSaveFailed(false);
+    setFailedSaveSeedKey(null);
 
     const result = await saveWorkout({
       persistMode: formSession.persistMode,
@@ -155,19 +195,18 @@ export default function WorkoutForm({
     });
 
     if (!result.ok) {
-      setHasSaveFailed(true);
+      setFailedSaveSeedKey(incomingSeedKey);
       return;
     }
 
-    setHasSaveFailed(false);
+    setFailedSaveSeedKey(null);
     reset(submittedSnapshot);
 
     if (formSession.persistMode === "create") {
-      setFormSession((currentSession) => ({
-        ...currentSession,
-        persistMode: "update",
+      setLocalCreatePromotion({
+        sourceSeedKey: incomingSeedKey,
         workoutId: result.workoutId,
-      }));
+      });
       window.history.replaceState(
         window.history.state,
         "",

--- a/components/workout-form/workout-form.tsx
+++ b/components/workout-form/workout-form.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
 import { Controller, useForm, useFieldArray, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/components/ui/button";
@@ -11,6 +10,7 @@ import WorkoutFormActionHeader, {
 } from "@/components/workout-form/workout-form-action-header";
 import { workoutFormSchema } from "@/lib/types";
 import type {
+  ExerciseTemplateValues,
   PersistMode,
   WorkoutDraft,
   WorkoutFormProps,
@@ -63,6 +63,12 @@ const getSaveStatus = ({
   return "saved";
 };
 
+type WorkoutFormSession = {
+  persistMode: PersistMode;
+  workoutId?: number;
+  templateValuesByExerciseName?: Record<string, ExerciseTemplateValues>;
+};
+
 export default function WorkoutForm({
   initialValues,
   persistMode,
@@ -71,7 +77,11 @@ export default function WorkoutForm({
 }: WorkoutFormProps) {
   const [hasSaveFailed, setHasSaveFailed] = useState(false);
   const [exercises, setExercises] = useState<string[]>([]);
-  const router = useRouter();
+  const [formSession, setFormSession] = useState<WorkoutFormSession>(() => ({
+    persistMode,
+    workoutId: "workoutId" in props ? props.workoutId : undefined,
+    templateValuesByExerciseName,
+  }));
   const normalizedWorkoutValue = useMemo(
     () => normalizeWorkoutForm(initialValues),
     [initialValues],
@@ -96,9 +106,8 @@ export default function WorkoutForm({
     control,
     name: "exercises",
   });
-  const updateWorkoutId = "workoutId" in props ? props.workoutId : undefined;
   const saveStatus = getSaveStatus({
-    persistMode,
+    persistMode: formSession.persistMode,
     hasSaveFailed,
     isDirty,
     isSubmitting,
@@ -140,8 +149,8 @@ export default function WorkoutForm({
     setHasSaveFailed(false);
 
     const result = await saveWorkout({
-      persistMode,
-      workoutId: updateWorkoutId,
+      persistMode: formSession.persistMode,
+      workoutId: formSession.workoutId,
       values: submittedSnapshot,
     });
 
@@ -151,13 +160,20 @@ export default function WorkoutForm({
     }
 
     setHasSaveFailed(false);
-
-    if (persistMode === "create") {
-      router.push(`/workouts/edit/${result.workoutId}`);
-      return;
-    }
-
     reset(submittedSnapshot);
+
+    if (formSession.persistMode === "create") {
+      setFormSession((currentSession) => ({
+        ...currentSession,
+        persistMode: "update",
+        workoutId: result.workoutId,
+      }));
+      window.history.replaceState(
+        window.history.state,
+        "",
+        `/workouts/edit/${result.workoutId}`,
+      );
+    }
   };
 
   return (
@@ -173,7 +189,7 @@ export default function WorkoutForm({
           {fields.map((field, index) => {
             const exerciseName = watchedExercises?.[index]?.name || "";
             const templateExercise = exerciseName
-              ? templateValuesByExerciseName?.[exerciseName]
+              ? formSession.templateValuesByExerciseName?.[exerciseName]
               : undefined;
 
             return (
@@ -189,9 +205,7 @@ export default function WorkoutForm({
                 onMoveDown={() => move(index, index + 1)}
                 isFirst={index === 0}
                 isLast={index === fields.length - 1}
-                workoutId={
-                  persistMode === "update" ? updateWorkoutId : undefined
-                }
+                workoutId={formSession.workoutId}
                 templateExercise={templateExercise}
               />
             );

--- a/components/workout-form/workout-form.tsx
+++ b/components/workout-form/workout-form.tsx
@@ -9,11 +9,12 @@ import WorkoutFormHeader from "@/components/workout-form/workout-form-header";
 import WorkoutFormActionHeader, {
   WorkoutSaveStatus,
 } from "@/components/workout-form/workout-form-action-header";
-import {
-  workoutFormSchema,
-  TWorkoutFormSchema,
-  ExerciseThin,
-} from "@/lib/types";
+import { workoutFormSchema } from "@/lib/types";
+import type {
+  ExerciseTemplateValues,
+  PersistMode,
+  WorkoutDraft,
+} from "@/components/workout-form/form-model";
 import { toast } from "sonner";
 import {
   Field,
@@ -24,23 +25,23 @@ import {
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 
-const cloneWorkoutForm = (values: TWorkoutFormSchema) => structuredClone(values);
+const cloneWorkoutForm = (values: WorkoutDraft) => structuredClone(values);
 const getTodayDate = () => new Date().toLocaleDateString("en-CA");
 
 const normalizeWorkoutForm = (
-  values: TWorkoutFormSchema,
-): TWorkoutFormSchema => ({
+  values: WorkoutDraft,
+): WorkoutDraft => ({
   ...values,
   date: values.date || getTodayDate(),
 });
 
 const getSaveStatus = ({
-  editMode,
+  persistMode,
   hasSaveFailed,
   isDirty,
   isSubmitting,
 }: {
-  editMode: boolean;
+  persistMode: PersistMode;
   hasSaveFailed: boolean;
   isDirty: boolean;
   isSubmitting: boolean;
@@ -53,7 +54,7 @@ const getSaveStatus = ({
     return "failed";
   }
 
-  if (!editMode) {
+  if (persistMode === "create") {
     return "not_saved";
   }
 
@@ -64,30 +65,38 @@ const getSaveStatus = ({
   return "saved";
 };
 
-interface WorkoutFormProps {
-  editMode: boolean;
-  workoutValue: TWorkoutFormSchema;
+type CreateWorkoutFormProps = {
+  initialValues: WorkoutDraft;
+  persistMode: "create";
+  templateValuesByExerciseName?: Record<string, ExerciseTemplateValues>;
+};
+
+type UpdateWorkoutFormProps = {
+  initialValues: WorkoutDraft;
+  persistMode: "update";
   workoutId: number;
-  placeholderValues?: ExerciseThin[];
-}
+  templateValuesByExerciseName?: Record<string, ExerciseTemplateValues>;
+};
+
+type WorkoutFormProps = CreateWorkoutFormProps | UpdateWorkoutFormProps;
 
 export default function WorkoutForm({
-  editMode,
-  workoutValue,
-  workoutId,
-  placeholderValues,
+  initialValues,
+  persistMode,
+  templateValuesByExerciseName,
+  ...props
 }: WorkoutFormProps) {
   const [failedWorkoutValueToken, setFailedWorkoutValueToken] = useState<
-    TWorkoutFormSchema | null
+    WorkoutDraft | null
   >(null);
   const [exercises, setExercises] = useState<string[]>([]);
   const router = useRouter();
   const normalizedWorkoutValue = useMemo(
-    () => normalizeWorkoutForm(workoutValue),
-    [workoutValue],
+    () => normalizeWorkoutForm(initialValues),
+    [initialValues],
   );
   const workoutValueToken = normalizedWorkoutValue;
-  const form = useForm<TWorkoutFormSchema>({
+  const form = useForm<WorkoutDraft>({
     resolver: zodResolver(workoutFormSchema),
     values: normalizedWorkoutValue,
   });
@@ -108,8 +117,9 @@ export default function WorkoutForm({
     name: "exercises",
   });
   const hasSaveFailed = failedWorkoutValueToken === workoutValueToken;
+  const updateWorkoutId = "workoutId" in props ? props.workoutId : undefined;
   const saveStatus = getSaveStatus({
-    editMode,
+    persistMode,
     hasSaveFailed,
     isDirty,
     isSubmitting,
@@ -146,11 +156,11 @@ export default function WorkoutForm({
     };
   }, [hasSaveFailed, subscribe]);
 
-  const onSubmit = async (values: TWorkoutFormSchema) => {
+  const onSubmit = async (values: WorkoutDraft) => {
     const submittedSnapshot = cloneWorkoutForm(values);
     setFailedWorkoutValueToken(null);
 
-    if (!editMode) {
+    if (persistMode === "create") {
       const newWorkoutId = await createWorkout(submittedSnapshot);
       if (newWorkoutId) {
         router.push(`/workouts/edit/${newWorkoutId}`);
@@ -158,7 +168,11 @@ export default function WorkoutForm({
         setFailedWorkoutValueToken(workoutValueToken);
       }
     } else {
-      const wasSaved = await updateWorkout(workoutId, submittedSnapshot);
+      if (!("workoutId" in props) || props.workoutId == null) {
+        throw new Error("WorkoutForm requires workoutId in update mode");
+      }
+
+      const wasSaved = await updateWorkout(props.workoutId, submittedSnapshot);
 
       if (wasSaved) {
         setFailedWorkoutValueToken(null);
@@ -176,7 +190,7 @@ export default function WorkoutForm({
    * @returns the ID of the newly created workout, or null if creation failed
    */
   const createWorkout = async (
-    form: TWorkoutFormSchema,
+    form: WorkoutDraft,
   ): Promise<number | null> => {
     try {
       const response = await fetch("/api/workouts", {
@@ -209,7 +223,7 @@ export default function WorkoutForm({
    */
   const updateWorkout = async (
     id: number,
-    form: TWorkoutFormSchema,
+    form: WorkoutDraft,
   ): Promise<boolean> => {
     try {
       const response = await fetch(`/api/workouts/${id}`, {
@@ -255,23 +269,32 @@ export default function WorkoutForm({
                 Exercises
               </FieldLegend>
 
-              {fields.map((field, index) => (
-                <ExerciseItem
-                  key={field.id}
-                  index={index}
-                  control={control}
-                  getValues={getValues}
-                  exercises={exercises}
-                  exerciseName={watchedExercises?.[index]?.name || ""}
-                  onRemove={() => remove(index)}
-                  onMoveUp={() => move(index, index - 1)}
-                  onMoveDown={() => move(index, index + 1)}
-                  isFirst={index === 0}
-                  isLast={index === fields.length - 1}
-                  workoutId={workoutId}
-                  placeholderValues={placeholderValues}
-                />
-              ))}
+              {fields.map((field, index) => {
+                const exerciseName = watchedExercises?.[index]?.name || "";
+                const templateExercise = exerciseName
+                  ? templateValuesByExerciseName?.[exerciseName]
+                  : undefined;
+
+                return (
+                  <ExerciseItem
+                    key={field.id}
+                    index={index}
+                    control={control}
+                    getValues={getValues}
+                    exercises={exercises}
+                    exerciseName={exerciseName}
+                    onRemove={() => remove(index)}
+                    onMoveUp={() => move(index, index - 1)}
+                    onMoveDown={() => move(index, index + 1)}
+                    isFirst={index === 0}
+                    isLast={index === fields.length - 1}
+                    workoutId={
+                      persistMode === "update" ? updateWorkoutId : undefined
+                    }
+                    templateExercise={templateExercise}
+                  />
+                );
+              })}
 
               <Button
                 type="button"

--- a/components/workout-form/workout-form.tsx
+++ b/components/workout-form/workout-form.tsx
@@ -11,10 +11,10 @@ import WorkoutFormActionHeader, {
 } from "@/components/workout-form/workout-form-action-header";
 import { workoutFormSchema } from "@/lib/types";
 import type {
-  ExerciseTemplateValues,
   PersistMode,
   WorkoutDraft,
-} from "@/components/workout-form/form-model";
+  WorkoutFormProps,
+} from "@/components/workout-form/form-types";
 import { toast } from "sonner";
 import {
   Field,
@@ -64,21 +64,6 @@ const getSaveStatus = ({
 
   return "saved";
 };
-
-type CreateWorkoutFormProps = {
-  initialValues: WorkoutDraft;
-  persistMode: "create";
-  templateValuesByExerciseName?: Record<string, ExerciseTemplateValues>;
-};
-
-type UpdateWorkoutFormProps = {
-  initialValues: WorkoutDraft;
-  persistMode: "update";
-  workoutId: number;
-  templateValuesByExerciseName?: Record<string, ExerciseTemplateValues>;
-};
-
-type WorkoutFormProps = CreateWorkoutFormProps | UpdateWorkoutFormProps;
 
 export default function WorkoutForm({
   initialValues,

--- a/components/workout-form/workout-form.tsx
+++ b/components/workout-form/workout-form.tsx
@@ -15,7 +15,6 @@ import type {
   WorkoutDraft,
   WorkoutFormProps,
 } from "@/components/workout-form/form-types";
-import { toast } from "sonner";
 import {
   Field,
   FieldError,
@@ -24,6 +23,7 @@ import {
   FieldSet,
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
+import { saveWorkout } from "@/components/workout-form/save-workout";
 
 const cloneWorkoutForm = (values: WorkoutDraft) => structuredClone(values);
 const getTodayDate = () => new Date().toLocaleDateString("en-CA");
@@ -71,16 +71,13 @@ export default function WorkoutForm({
   templateValuesByExerciseName,
   ...props
 }: WorkoutFormProps) {
-  const [failedWorkoutValueToken, setFailedWorkoutValueToken] = useState<
-    WorkoutDraft | null
-  >(null);
+  const [hasSaveFailed, setHasSaveFailed] = useState(false);
   const [exercises, setExercises] = useState<string[]>([]);
   const router = useRouter();
   const normalizedWorkoutValue = useMemo(
     () => normalizeWorkoutForm(initialValues),
     [initialValues],
   );
-  const workoutValueToken = normalizedWorkoutValue;
   const form = useForm<WorkoutDraft>({
     resolver: zodResolver(workoutFormSchema),
     values: normalizedWorkoutValue,
@@ -101,7 +98,6 @@ export default function WorkoutForm({
     control,
     name: "exercises",
   });
-  const hasSaveFailed = failedWorkoutValueToken === workoutValueToken;
   const updateWorkoutId = "workoutId" in props ? props.workoutId : undefined;
   const saveStatus = getSaveStatus({
     persistMode,
@@ -131,7 +127,7 @@ export default function WorkoutForm({
           return;
         }
 
-        setFailedWorkoutValueToken(null);
+        setHasSaveFailed(false);
         unsubscribe();
       },
     });
@@ -143,93 +139,27 @@ export default function WorkoutForm({
 
   const onSubmit = async (values: WorkoutDraft) => {
     const submittedSnapshot = cloneWorkoutForm(values);
-    setFailedWorkoutValueToken(null);
+    setHasSaveFailed(false);
+
+    const result = await saveWorkout({
+      persistMode,
+      workoutId: updateWorkoutId,
+      values: submittedSnapshot,
+    });
+
+    if (!result.ok) {
+      setHasSaveFailed(true);
+      return;
+    }
+
+    setHasSaveFailed(false);
 
     if (persistMode === "create") {
-      const newWorkoutId = await createWorkout(submittedSnapshot);
-      if (newWorkoutId) {
-        router.push(`/workouts/edit/${newWorkoutId}`);
-      } else {
-        setFailedWorkoutValueToken(workoutValueToken);
-      }
-    } else {
-      if (!("workoutId" in props) || props.workoutId == null) {
-        throw new Error("WorkoutForm requires workoutId in update mode");
-      }
-
-      const wasSaved = await updateWorkout(props.workoutId, submittedSnapshot);
-
-      if (wasSaved) {
-        setFailedWorkoutValueToken(null);
-        reset(submittedSnapshot);
-      } else {
-        setFailedWorkoutValueToken(workoutValueToken);
-      }
+      router.push(`/workouts/edit/${result.workoutId}`);
+      return;
     }
-  };
 
-  /**
-   * Creates a new workout with the values from the form
-   *
-   * @param form the form values to create the workout with
-   * @returns the ID of the newly created workout, or null if creation failed
-   */
-  const createWorkout = async (
-    form: WorkoutDraft,
-  ): Promise<number | null> => {
-    try {
-      const response = await fetch("/api/workouts", {
-        method: "POST",
-        body: JSON.stringify(form),
-        headers: {
-          "Content-Type": "application/json",
-        },
-      });
-
-      if (!response.ok) {
-        toast.error("Failed to create workout");
-        return null;
-      }
-
-      const data = await response.json();
-      return data.workoutId;
-    } catch (error) {
-      console.error("An error occurred while creating workout:", error);
-      toast.error("Failed to create workout");
-      return null;
-    }
-  };
-
-  /**
-   * Updates an existing workout with the values from the form
-   *
-   * @param id the id of the workout to update
-   * @param form the form values to update the workout with
-   */
-  const updateWorkout = async (
-    id: number,
-    form: WorkoutDraft,
-  ): Promise<boolean> => {
-    try {
-      const response = await fetch(`/api/workouts/${id}`, {
-        method: "PATCH",
-        body: JSON.stringify(form),
-        headers: {
-          "Content-Type": "application/json",
-        },
-      });
-
-      if (!response.ok) {
-        toast.error("Failed to save workout");
-        return false;
-      }
-
-      return true;
-    } catch (error) {
-      console.error("An error occurred while updating exercise:", error);
-      toast.error("Failed to save workout");
-      return false;
-    }
+    reset(submittedSnapshot);
   };
 
   return (

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.2",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "25.5.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -57,6 +59,7 @@
     "eslint": "^9.39.2",
     "eslint-config-next": "^16.2.2",
     "eslint-config-prettier": "^10.1.8",
+    "jsdom": "^29.0.1",
     "postcss": "^8.5.8",
     "prettier": "3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,12 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: 25.5.2
         version: 25.5.2
@@ -117,6 +123,9 @@ importers:
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@9.39.2(jiti@2.6.1))
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1
       postcss:
         specifier: ^8.5.8
         version: 8.5.8
@@ -143,13 +152,24 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+        version: 3.2.4(@types/node@25.5.2)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
 packages:
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@5.1.6':
+    resolution: {integrity: sha512-BXWCh8dHs9GOfpo/fWGDJtDmleta2VePN9rn6WQt3GjEbxzutVF4t0x2pmH+7dbMCLtuv3MlwqRsAuxlzFXqFg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.0.7':
+    resolution: {integrity: sha512-d2BgqDUOS1Hfp4IzKUZqCNz+Kg3Y88AkaBvJK/ZVSQPU1f7OpPNi7nQTH6/oI47Dkdg+Z3e8Yp6ynOu4UMINAQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -206,6 +226,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -217,6 +241,10 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
 
   '@clerk/backend@3.2.4':
     resolution: {integrity: sha512-zEK0xE47dVZl1AAovMbiG95kxXjEt9A2RKNEmIJveuXoNdX5AK5yV6vdCEFTblhymlFAYvTr+NHIe6iJAtp50g==}
@@ -248,6 +276,42 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2':
+    resolution: {integrity: sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -750,6 +814,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
@@ -1741,8 +1814,36 @@ packages:
   '@tanstack/query-core@5.90.16':
     resolution: {integrity: sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1999,9 +2100,17 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2009,6 +2118,9 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2080,6 +2192,9 @@ packages:
     resolution: {integrity: sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
@@ -2184,6 +2299,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -2193,6 +2312,10 @@ packages:
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -2222,6 +2345,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -2256,6 +2382,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   drizzle-kit@0.31.10:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
@@ -2366,6 +2495,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   es-abstract@1.24.1:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
@@ -2726,6 +2859,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2813,6 +2950,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -2879,6 +3019,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.0.1:
+    resolution: {integrity: sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -3010,6 +3159,10 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@11.3.2:
+    resolution: {integrity: sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -3018,12 +3171,19 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -3163,6 +3323,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3268,6 +3431,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   promise-limit@2.7.0:
     resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
 
@@ -3294,6 +3461,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -3337,6 +3507,10 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3372,6 +3546,10 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3523,6 +3701,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
@@ -3560,12 +3741,27 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -3625,6 +3821,10 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici@7.24.7:
+    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
+    engines: {node: '>=20.18.1'}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -3736,12 +3936,28 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -3801,6 +4017,13 @@ packages:
     engines: {node: '>=0.8'}
     hasBin: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -3820,6 +4043,22 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@5.1.6':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.0.7':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3898,6 +4137,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -3920,6 +4161,10 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
 
   '@clerk/backend@3.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -3958,6 +4203,30 @@ snapshots:
     optionalDependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -4254,6 +4523,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.0': {}
 
   '@floating-ui/core@1.7.3':
     dependencies:
@@ -5098,10 +5369,37 @@ snapshots:
 
   '@tanstack/query-core@5.90.16': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -5344,15 +5642,23 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -5442,6 +5748,10 @@ snapshots:
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.14: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   brace-expansion@1.1.13:
     dependencies:
@@ -5555,11 +5865,23 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
 
   data-uri-to-buffer@4.0.1: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -5586,6 +5908,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-eql@5.0.2: {}
 
@@ -5615,6 +5939,8 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-accessibility-api@0.5.16: {}
+
   drizzle-kit@0.31.10:
     dependencies:
       '@drizzle-team/brocli': 0.10.2
@@ -5641,6 +5967,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  entities@6.0.1: {}
 
   es-abstract@1.24.1:
     dependencies:
@@ -6208,6 +6536,12 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -6298,6 +6632,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -6363,6 +6699,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.6
+      '@asamuzakjp/dom-selector': 7.0.7
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.2
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.24.7
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -6476,6 +6838,8 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@11.3.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -6484,11 +6848,15 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   merge2@1.4.1: {}
 
@@ -6634,6 +7002,10 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -6672,6 +7044,12 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   promise-limit@2.7.0: {}
 
   prop-types@15.8.1:
@@ -6694,6 +7072,8 @@ snapshots:
       react: 19.2.4
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
     dependencies:
@@ -6743,6 +7123,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -6812,6 +7194,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -7016,6 +7402,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@3.5.0: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@4.2.2):
@@ -7041,11 +7429,25 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.0.28: {}
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.28
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.5.0(typescript@6.0.2):
     dependencies:
@@ -7127,6 +7529,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@7.18.2: {}
+
+  undici@7.24.7: {}
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -7217,7 +7621,7 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.21.0
 
-  vitest@3.2.4(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
+  vitest@3.2.4(@types/node@25.5.2)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -7244,6 +7648,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.2
+      jsdom: 29.0.1
     transitivePeerDependencies:
       - jiti
       - less
@@ -7258,9 +7663,25 @@ snapshots:
       - tsx
       - yaml
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -7334,6 +7755,10 @@ snapshots:
       ssf: 0.11.2
       wmf: 1.0.2
       word: 0.3.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["./**/*.ts", "./**/*.tsx", "../vitest.config.ts"],
+  "exclude": ["../node_modules"]
+}

--- a/tests/workout-form/form-model.test.ts
+++ b/tests/workout-form/form-model.test.ts
@@ -1,8 +1,32 @@
-import { describe, expect, it } from "vitest";
-import {
-  buildDuplicateWorkoutFormSeed,
-} from "@/components/workout-form/form-model";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Workout } from "@/lib/types";
+
+const { authMock, findFirstMock } = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  findFirstMock: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: authMock,
+}));
+
+vi.mock("@/db/drizzle", () => ({
+  db: {
+    query: {
+      workout: {
+        findFirst: findFirstMock,
+      },
+    },
+  },
+}));
+
+import {
+  buildBlankWorkoutFormSeed,
+  buildDuplicateWorkoutFormSeed,
+  buildEditWorkoutFormSeed,
+  buildWorkoutFormSeed,
+  getWorkoutFormTodayDate,
+} from "@/components/workout-form/form-model";
 
 const workoutFixture: Workout = {
   id: 1,
@@ -25,13 +49,71 @@ const workoutFixture: Workout = {
   ],
 };
 
-describe("buildDuplicateWorkoutFormSeed", () => {
+describe("workout form seed builders", () => {
+  beforeEach(() => {
+    authMock.mockReset();
+    authMock.mockResolvedValue({
+      userId: "user-1",
+      redirectToSignIn: vi.fn(),
+    });
+    findFirstMock.mockReset();
+    vi.useRealTimers();
+  });
+
+  it("builds a blank create seed with today's date and one empty exercise row", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-05T12:00:00.000Z"));
+
+    expect(buildBlankWorkoutFormSeed()).toEqual({
+      persistMode: "create",
+      initialValues: {
+        name: "",
+        date: "2026-04-05",
+        notes: "",
+        durationMinutes: null,
+        exercises: [
+          {
+            name: "",
+            notes: "",
+            sets: [{ weight: "", reps: "", rpe: "" }],
+          },
+        ],
+      },
+    });
+  });
+
+  it("builds an edit seed that preserves the workout values and id", () => {
+    expect(buildEditWorkoutFormSeed(workoutFixture)).toEqual({
+      persistMode: "update",
+      workoutId: 1,
+      initialValues: {
+        name: "Push Day",
+        date: "2026-04-04",
+        notes: "Original notes",
+        durationMinutes: 70,
+        exercises: [
+          {
+            name: "Bench Press",
+            notes: "Original exercise notes",
+            sets: [
+              { weight: "225", reps: "5", rpe: "8" },
+              { weight: "235", reps: "3", rpe: "9" },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
   it("builds a duplicate form seed from the helper pipeline", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-05T12:00:00.000Z"));
+
     expect(buildDuplicateWorkoutFormSeed(workoutFixture)).toEqual({
       persistMode: "create",
       initialValues: {
         name: "Copy of Push Day",
-        date: expect.any(String),
+        date: "2026-04-05",
         notes: "",
         durationMinutes: null,
         exercises: [
@@ -101,5 +183,38 @@ describe("buildDuplicateWorkoutFormSeed", () => {
       },
       templateValuesByExerciseName: {},
     });
+  });
+
+  it("formats today's date as YYYY-MM-DD", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-05T12:00:00.000Z"));
+
+    expect(getWorkoutFormTodayDate()).toBe("2026-04-05");
+  });
+
+  it("routes create mode through the shared builder without querying the database", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-05T12:00:00.000Z"));
+
+    await expect(buildWorkoutFormSeed({ kind: "create" })).resolves.toEqual(
+      buildBlankWorkoutFormSeed(),
+    );
+    expect(findFirstMock).not.toHaveBeenCalled();
+  });
+
+  it("returns an edit seed from the shared builder when the workout is found", async () => {
+    findFirstMock.mockResolvedValueOnce(workoutFixture);
+
+    await expect(
+      buildWorkoutFormSeed({ kind: "edit", workoutId: 1 }),
+    ).resolves.toEqual(buildEditWorkoutFormSeed(workoutFixture));
+  });
+
+  it("returns null from the shared builder when the workout is missing", async () => {
+    findFirstMock.mockResolvedValueOnce(null);
+
+    await expect(
+      buildWorkoutFormSeed({ kind: "duplicate", workoutId: 1 }),
+    ).resolves.toBeNull();
   });
 });

--- a/tests/workout-form/form-model.test.ts
+++ b/tests/workout-form/form-model.test.ts
@@ -1,48 +1,105 @@
 import { describe, expect, it } from "vitest";
 import {
-  toTemplateValuesByExerciseName,
-  type ExerciseTemplateValues,
+  buildDuplicateWorkoutFormSeed,
 } from "@/components/workout-form/form-model";
+import type { Workout } from "@/lib/types";
 
-describe("toTemplateValuesByExerciseName", () => {
-  it("returns a keyed object by exercise name", () => {
-    const hints: ExerciseTemplateValues[] = [
-      {
-        name: "Bench Press",
-        notes: "",
-        sets: [{ weight: "225", reps: "5", rpe: "8" }],
-      },
-      {
-        name: "Row",
-        notes: "",
-        sets: [{ weight: "185", reps: "8", rpe: "7" }],
-      },
-    ];
+const workoutFixture: Workout = {
+  id: 1,
+  name: "Push Day",
+  notes: "Original notes",
+  durationMinutes: 70,
+  userId: "user-1",
+  date: "2026-04-04",
+  exercises: [
+    {
+      id: 11,
+      name: "Bench Press",
+      notes: "Original exercise notes",
+      workoutId: 1,
+      sets: [
+        { id: 111, weight: "225", reps: "5", rpe: "8", exerciseId: 11 },
+        { id: 112, weight: "235", reps: "3", rpe: "9", exerciseId: 11 },
+      ],
+    },
+  ],
+};
 
-    expect(toTemplateValuesByExerciseName(hints)).toEqual({
-      "Bench Press": hints[0],
-      Row: hints[1],
+describe("buildDuplicateWorkoutFormSeed", () => {
+  it("builds a duplicate form seed from the helper pipeline", () => {
+    expect(buildDuplicateWorkoutFormSeed(workoutFixture)).toEqual({
+      persistMode: "create",
+      initialValues: {
+        name: "Copy of Push Day",
+        date: expect.any(String),
+        notes: "",
+        durationMinutes: null,
+        exercises: [
+          {
+            name: "Bench Press",
+            notes: "",
+            sets: [
+              { weight: "", reps: "", rpe: "" },
+              { weight: "", reps: "", rpe: "" },
+            ],
+          },
+        ],
+      },
+      templateValuesByExerciseName: {
+        "Bench Press": {
+          name: "Bench Press",
+          notes: "",
+          sets: [
+            { weight: "225", reps: "5", rpe: "8" },
+            { weight: "235", reps: "3", rpe: "9" },
+          ],
+        },
+      },
     });
   });
 
-  it("preserves the first matching exercise when duplicate names exist", () => {
-    const firstHint: ExerciseTemplateValues = {
-      name: "Bench Press",
-      notes: "first",
-      sets: [{ weight: "225", reps: "5", rpe: "8" }],
-    };
-    const secondHint: ExerciseTemplateValues = {
-      name: "Bench Press",
-      notes: "second",
-      sets: [{ weight: "235", reps: "3", rpe: "9" }],
-    };
-
+  it("keeps the first matching exercise when duplicate names exist", () => {
     expect(
-      toTemplateValuesByExerciseName([firstHint, secondHint])["Bench Press"],
-    ).toBe(firstHint);
+      buildDuplicateWorkoutFormSeed({
+        ...workoutFixture,
+        exercises: [
+          workoutFixture.exercises[0],
+          {
+            ...workoutFixture.exercises[0],
+            id: 12,
+            notes: "second",
+            sets: [{ id: 121, weight: "245", reps: "2", rpe: "9.5", exerciseId: 12 }],
+          },
+        ],
+      }).templateValuesByExerciseName,
+    ).toEqual({
+      "Bench Press": {
+        name: "Bench Press",
+        notes: "",
+        sets: [
+          { weight: "225", reps: "5", rpe: "8" },
+          { weight: "235", reps: "3", rpe: "9" },
+        ],
+      },
+    });
   });
 
-  it("returns an empty object for an empty list", () => {
-    expect(toTemplateValuesByExerciseName([])).toEqual({});
+  it("returns empty template values when there are no exercises", () => {
+    expect(
+      buildDuplicateWorkoutFormSeed({
+        ...workoutFixture,
+        exercises: [],
+      }),
+    ).toEqual({
+      persistMode: "create",
+      initialValues: {
+        name: "Copy of Push Day",
+        date: expect.any(String),
+        notes: "",
+        durationMinutes: null,
+        exercises: [],
+      },
+      templateValuesByExerciseName: {},
+    });
   });
 });

--- a/tests/workout-form/form-model.test.ts
+++ b/tests/workout-form/form-model.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  toTemplateValuesByExerciseName,
+  type ExerciseTemplateValues,
+} from "@/components/workout-form/form-model";
+
+describe("toTemplateValuesByExerciseName", () => {
+  it("returns a keyed object by exercise name", () => {
+    const hints: ExerciseTemplateValues[] = [
+      {
+        name: "Bench Press",
+        notes: "",
+        sets: [{ weight: "225", reps: "5", rpe: "8" }],
+      },
+      {
+        name: "Row",
+        notes: "",
+        sets: [{ weight: "185", reps: "8", rpe: "7" }],
+      },
+    ];
+
+    expect(toTemplateValuesByExerciseName(hints)).toEqual({
+      "Bench Press": hints[0],
+      Row: hints[1],
+    });
+  });
+
+  it("preserves the first matching exercise when duplicate names exist", () => {
+    const firstHint: ExerciseTemplateValues = {
+      name: "Bench Press",
+      notes: "first",
+      sets: [{ weight: "225", reps: "5", rpe: "8" }],
+    };
+    const secondHint: ExerciseTemplateValues = {
+      name: "Bench Press",
+      notes: "second",
+      sets: [{ weight: "235", reps: "3", rpe: "9" }],
+    };
+
+    expect(
+      toTemplateValuesByExerciseName([firstHint, secondHint])["Bench Press"],
+    ).toBe(firstHint);
+  });
+
+  it("returns an empty object for an empty list", () => {
+    expect(toTemplateValuesByExerciseName([])).toEqual({});
+  });
+});

--- a/tests/workout-form/save-workout.test.ts
+++ b/tests/workout-form/save-workout.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkoutDraft } from "@/components/workout-form/form-types";
+
+const { toastErrorMock } = vi.hoisted(() => ({
+  toastErrorMock: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastErrorMock,
+  },
+}));
+
+import { saveWorkout } from "@/components/workout-form/save-workout";
+
+const workoutDraftFixture: WorkoutDraft = {
+  name: "Push Day",
+  date: "2026-04-06",
+  notes: "Top sets",
+  durationMinutes: 65,
+  exercises: [
+    {
+      name: "Bench Press",
+      notes: "Pause the first rep",
+      sets: [{ weight: "225", reps: "5", rpe: "8" }],
+    },
+  ],
+};
+
+describe("saveWorkout", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    toastErrorMock.mockReset();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the new workout id for create success and sends the normalized request", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ workoutId: 42 }), {
+        status: 201,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+
+    await expect(
+      saveWorkout({
+        persistMode: "create",
+        values: workoutDraftFixture,
+      }),
+    ).resolves.toEqual({ ok: true, workoutId: 42 });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/workouts", {
+      method: "POST",
+      body: JSON.stringify(workoutDraftFixture),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the existing workout id for update success and patches the workout", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "Workout updated" }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+
+    await expect(
+      saveWorkout({
+        persistMode: "update",
+        workoutId: 17,
+        values: workoutDraftFixture,
+      }),
+    ).resolves.toEqual({ ok: true, workoutId: 17 });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/workouts/17", {
+      method: "PATCH",
+      body: JSON.stringify(workoutDraftFixture),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a failed result and emits the create toast for non-ok create responses", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "bad request" }), {
+        status: 400,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+
+    await expect(
+      saveWorkout({
+        persistMode: "create",
+        values: workoutDraftFixture,
+      }),
+    ).resolves.toEqual({ ok: false });
+
+    expect(toastErrorMock).toHaveBeenCalledWith("Failed to create workout");
+  });
+
+  it("returns a failed result and emits the update toast for non-ok update responses", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "not found" }), {
+        status: 404,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+
+    await expect(
+      saveWorkout({
+        persistMode: "update",
+        workoutId: 17,
+        values: workoutDraftFixture,
+      }),
+    ).resolves.toEqual({ ok: false });
+
+    expect(toastErrorMock).toHaveBeenCalledWith("Failed to save workout");
+  });
+
+  it("returns a failed result and emits the create toast when the create success payload is malformed", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "Workout created" }), {
+        status: 201,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+
+    await expect(
+      saveWorkout({
+        persistMode: "create",
+        values: workoutDraftFixture,
+      }),
+    ).resolves.toEqual({ ok: false });
+
+    expect(toastErrorMock).toHaveBeenCalledWith("Failed to create workout");
+  });
+
+  it("throws before fetching when update mode is missing a workout id", async () => {
+    const fetchMock = vi.mocked(fetch);
+
+    await expect(
+      saveWorkout({
+        persistMode: "update",
+        values: workoutDraftFixture,
+      }),
+    ).rejects.toThrow("saveWorkout requires workoutId in update mode");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/workout-form/workout-form-promotion.test.tsx
+++ b/tests/workout-form/workout-form-promotion.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { WorkoutDraft } from "@/components/workout-form/form-types";
+
+vi.mock("@/components/ui/sidebar", () => ({
+  SidebarTrigger: (props: React.ComponentProps<"button">) => (
+    <button type="button" {...props}>
+      Sidebar
+    </button>
+  ),
+}));
+
+vi.mock("@/components/workout-form/exercise-item", async () => {
+  return {
+    default: function MockExerciseItem({
+      index,
+      exerciseName,
+      workoutId,
+      templateExercise,
+    }: {
+      index: number;
+      exerciseName: string;
+      workoutId?: number;
+      templateExercise?: { name: string };
+    }) {
+      return (
+        <div
+          data-testid={`exercise-item-${index}`}
+          data-exercise-name={exerciseName}
+          data-has-template={String(Boolean(templateExercise))}
+          data-workout-id={workoutId?.toString() ?? ""}
+        >
+          Exercise row {index}
+        </div>
+      );
+    },
+  };
+});
+
+import WorkoutForm from "@/components/workout-form/workout-form";
+
+const workoutDraftFixture: WorkoutDraft = {
+  name: "Push Day",
+  date: "2026-04-06",
+  notes: "Top sets",
+  durationMinutes: 65,
+  exercises: [
+    {
+      name: "Bench Press",
+      notes: "Pause the first rep",
+      sets: [{ weight: "225", reps: "5", rpe: "8" }],
+    },
+  ],
+};
+
+function createFetchResponse(body: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+    },
+    ...init,
+  });
+}
+
+function getWorkoutSaveCalls(fetchMock: ReturnType<typeof vi.fn>) {
+  return fetchMock.mock.calls.filter(([url]) =>
+    typeof url === "string" && url.startsWith("/api/workouts"),
+  );
+}
+
+describe("WorkoutForm promotion flow", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+
+      if (url === "/api/exercises" && method === "GET") {
+        return createFetchResponse(["Bench Press", "Overhead Press"]);
+      }
+
+      if (url === "/api/workouts" && method === "POST") {
+        return createFetchResponse({ workoutId: 42 }, { status: 201 });
+      }
+
+      if (url === "/api/workouts/42" && method === "PATCH") {
+        return createFetchResponse({ message: "Workout updated" });
+      }
+
+      throw new Error(`Unexpected fetch request: ${method} ${url}`);
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("promotes create mode to update mode in place after the first save", async () => {
+    const replaceStateSpy = vi.spyOn(window.history, "replaceState");
+    const user = userEvent.setup();
+
+    render(
+      <WorkoutForm
+        initialValues={workoutDraftFixture}
+        persistMode="create"
+      />,
+    );
+
+    await screen.findByTestId("exercise-item-0");
+    const workoutNameInput = screen.getByLabelText("Workout Name");
+
+    expect(screen.getByText("Not saved")).toBeTruthy();
+    expect(
+      screen.getByTestId("exercise-item-0").getAttribute("data-workout-id"),
+    ).toBe("");
+
+    await user.clear(workoutNameInput);
+    await user.type(workoutNameInput, "Promoted Push Day");
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await screen.findByText("Saved");
+
+    const replaceStateCall = replaceStateSpy.mock.calls.at(-1);
+    expect(replaceStateCall).toBeTruthy();
+    expect(replaceStateCall?.[2]).toBe("/workouts/edit/42");
+
+    expect(screen.getByTestId("exercise-item-0").textContent).toContain(
+      "Exercise row 0",
+    );
+    expect(
+      screen.getByTestId("exercise-item-0").getAttribute("data-workout-id"),
+    ).toBe("42");
+    expect(
+      (screen.getByLabelText("Workout Name") as HTMLInputElement).value,
+    ).toBe("Promoted Push Day");
+
+    const fetchMock = vi.mocked(fetch);
+    expect(getWorkoutSaveCalls(fetchMock)).toHaveLength(1);
+    expect(getWorkoutSaveCalls(fetchMock)[0]?.[0]).toBe("/api/workouts");
+    expect(getWorkoutSaveCalls(fetchMock)[0]?.[1]).toMatchObject({
+      method: "POST",
+    });
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(getWorkoutSaveCalls(fetchMock)).toHaveLength(2);
+    });
+
+    expect(getWorkoutSaveCalls(fetchMock)[1]?.[0]).toBe("/api/workouts/42");
+    expect(getWorkoutSaveCalls(fetchMock)[1]?.[1]).toMatchObject({
+      method: "PATCH",
+    });
+  });
+
+  it("keeps duplicate template hints after the first successful save", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <WorkoutForm
+        initialValues={workoutDraftFixture}
+        persistMode="create"
+        templateValuesByExerciseName={{
+          "Bench Press": {
+            name: "Bench Press",
+            notes: "",
+            sets: [{ weight: "200", reps: "6", rpe: "7" }],
+          },
+        }}
+      />,
+    );
+
+    const exerciseRow = await screen.findByTestId("exercise-item-0");
+    expect(exerciseRow.getAttribute("data-has-template")).toBe("true");
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await screen.findByText("Saved");
+
+    expect(
+      screen.getByTestId("exercise-item-0").getAttribute("data-has-template"),
+    ).toBe("true");
+  });
+});

--- a/tests/workout-form/workout-form-promotion.test.tsx
+++ b/tests/workout-form/workout-form-promotion.test.tsx
@@ -57,6 +57,15 @@ const workoutDraftFixture: WorkoutDraft = {
   ],
 };
 
+function buildWorkoutDraft(
+  overrides: Partial<WorkoutDraft> = {},
+): WorkoutDraft {
+  return {
+    ...structuredClone(workoutDraftFixture),
+    ...overrides,
+  };
+}
+
 function createFetchResponse(body: unknown, init?: ResponseInit) {
   return new Response(JSON.stringify(body), {
     status: 200,
@@ -123,6 +132,8 @@ describe("WorkoutForm promotion flow", () => {
     await user.clear(workoutNameInput);
     await user.type(workoutNameInput, "Promoted Push Day");
 
+    expect(screen.getByText("Not saved")).toBeTruthy();
+
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     await screen.findByText("Saved");
@@ -157,6 +168,142 @@ describe("WorkoutForm promotion flow", () => {
     expect(getWorkoutSaveCalls(fetchMock)[1]?.[0]).toBe("/api/workouts/42");
     expect(getWorkoutSaveCalls(fetchMock)[1]?.[1]).toMatchObject({
       method: "PATCH",
+    });
+  });
+
+  it("preserves local edits when rerendered with equal-content props", async () => {
+    const user = userEvent.setup();
+    const createSeed = buildWorkoutDraft();
+    const { rerender } = render(
+      <WorkoutForm
+        initialValues={createSeed}
+        persistMode="update"
+        workoutId={17}
+      />,
+    );
+
+    await screen.findByTestId("exercise-item-0");
+    const workoutNameInput = screen.getByLabelText(
+      "Workout Name",
+    ) as HTMLInputElement;
+
+    await user.clear(workoutNameInput);
+    await user.type(workoutNameInput, "Edited Locally");
+
+    expect(screen.getByText("Unsaved changes")).toBeTruthy();
+    expect(workoutNameInput.value).toBe("Edited Locally");
+
+    rerender(
+      <WorkoutForm
+        initialValues={buildWorkoutDraft()}
+        persistMode="update"
+        workoutId={17}
+      />,
+    );
+
+    expect(screen.getByText("Unsaved changes")).toBeTruthy();
+    expect(
+      (screen.getByLabelText("Workout Name") as HTMLInputElement).value,
+    ).toBe("Edited Locally");
+  });
+
+  it("replaces the form when the external seed changes", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <WorkoutForm
+        initialValues={buildWorkoutDraft()}
+        persistMode="create"
+      />,
+    );
+
+    const workoutNameInput = (await screen.findByLabelText(
+      "Workout Name",
+    )) as HTMLInputElement;
+
+    await user.clear(workoutNameInput);
+    await user.type(workoutNameInput, "Temporary edit");
+
+    expect(screen.getByText("Not saved")).toBeTruthy();
+
+    rerender(
+      <WorkoutForm
+        initialValues={buildWorkoutDraft({
+          name: "Leg Day",
+          date: "2026-04-08",
+        })}
+        persistMode="update"
+        workoutId={77}
+        templateValuesByExerciseName={{
+          "Bench Press": {
+            name: "Bench Press",
+            notes: "",
+            sets: [{ weight: "205", reps: "5", rpe: "8" }],
+          },
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Saved")).toBeTruthy();
+      expect(
+        (screen.getByLabelText("Workout Name") as HTMLInputElement).value,
+      ).toBe("Leg Day");
+      expect(
+        screen.getByTestId("exercise-item-0").getAttribute("data-workout-id"),
+      ).toBe("77");
+      expect(
+        screen.getByTestId("exercise-item-0").getAttribute("data-has-template"),
+      ).toBe("true");
+    });
+  });
+
+  it("clears stale save failure state when a new external seed arrives", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+
+      if (url === "/api/exercises" && method === "GET") {
+        return createFetchResponse(["Bench Press", "Overhead Press"]);
+      }
+
+      if (url === "/api/workouts" && method === "POST") {
+        return createFetchResponse({ error: "bad request" }, { status: 400 });
+      }
+
+      throw new Error(`Unexpected fetch request: ${method} ${url}`);
+    });
+
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <WorkoutForm
+        initialValues={buildWorkoutDraft()}
+        persistMode="create"
+      />,
+    );
+
+    await screen.findByTestId("exercise-item-0");
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await screen.findByText("Save failed");
+
+    rerender(
+      <WorkoutForm
+        initialValues={buildWorkoutDraft({
+          name: "Recovered Seed",
+        })}
+        persistMode="update"
+        workoutId={88}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("Save failed")).toBeNull();
+      expect(screen.getByText("Saved")).toBeTruthy();
+      expect(
+        (screen.getByLabelText("Workout Name") as HTMLInputElement).value,
+      ).toBe("Recovered Seed");
     });
   });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
     restoreMocks: true,
     clearMocks: true,
   },

--- a/workout-form-cleanup-and-save-ux-refactor-plan.md
+++ b/workout-form-cleanup-and-save-ux-refactor-plan.md
@@ -1,0 +1,307 @@
+# Workout Form Cleanup And Save UX Refactor Plan
+
+## Summary
+Refactor the workout form into a single long-lived client form with explicit persistence modes, shared server seed builders, narrower render subscriptions, and a no-page-turn create/duplicate save flow. The implementation is staged so each step is independently shippable, with architecture cleanup first, UX improvement second, and performance/testing follow-ups after the new shape is stable.
+
+## Assumptions And Defaults
+- “Duplicate” is not a separate persistence path. It is a seeded create flow that uses `POST` on first save.
+- After the first successful create/duplicate save, the current mounted form should remain on screen and become an edit/update form locally.
+- The URL should update to `/workouts/edit/:id` without a visible route transition. Use `window.history.replaceState(...)`, not `router.push(...)` or `router.replace(...)`.
+- Existing API routes remain in place: `POST /api/workouts` and `PATCH /api/workouts/:id`.
+- The current destructive `PATCH` rewrite strategy remains for this refactor; diff-based updates are a later follow-up.
+- Testing uses Vitest, matching the existing route test setup in [tests/routes/workouts-routes.test.ts](/Users/kevintatooles/Desktop/Projects/next-fitness-tracker/tests/routes/workouts-routes.test.ts).
+
+## Public API / Interface / Type Changes
+- Replace `WorkoutFormProps` in [workout-form.tsx](/Users/kevintatooles/Desktop/Projects/next-fitness-tracker/components/workout-form/workout-form.tsx) from:
+  - `editMode: boolean`
+  - `workoutId: number`
+  - `workoutValue: TWorkoutFormSchema`
+  - `placeholderValues?: ExerciseThin[]`
+- With a decision-complete prop contract:
+  - `initialValues: WorkoutDraft`
+  - `persistMode: "create" | "update"`
+  - `workoutId?: number`
+  - `templateValuesByExerciseName?: Record<string, ExerciseTemplateHint>`
+- Introduce explicit client types in a shared form-model module:
+  - `type WorkoutDraft = TWorkoutFormSchema`
+  - `type ExerciseTemplateHint = ExerciseThin`
+  - `type WorkoutFormSeed = { initialValues: WorkoutDraft; persistMode: "create" | "update"; workoutId?: number; templateValuesByExerciseName?: Record<string, ExerciseTemplateHint> }`
+  - `type SaveState = "idle" | "saving" | "saved" | "failed"`
+- Add shared server helper interfaces:
+  - `buildWorkoutFormSeed({ kind: "create" | "edit" | "duplicate"; workoutId?: number }): Promise<WorkoutFormSeed | null>`
+- Add shared client save helper interface:
+  - `saveWorkout({ persistMode, workoutId, values }): Promise<{ ok: true; workoutId: number } | { ok: false }>`
+
+## Ordered Implementation Steps
+
+### 1. Model form persistence explicitly
+Create a shared form model module that defines `WorkoutDraft`, `WorkoutFormSeed`, `ExerciseTemplateHint`, and `SaveState`. Replace boolean `editMode` semantics with `persistMode: "create" | "update"` everywhere the form is invoked.
+
+**Implementation details**
+- Put the shared types and seed builders in a dedicated module under `components/workout-form` or `lib`.
+- Keep `duplicate` as a route-level seed choice, not a form-level persistence mode.
+
+**Acceptance criteria**
+- No component uses `editMode`.
+- No component passes `workoutId={-1}`.
+- The form can distinguish “first save uses POST” vs “subsequent saves use PATCH” without sentinel values.
+
+---
+
+### 2. Extract shared server-side seed builders
+Move create/edit/duplicate data shaping out of route pages into one server helper. That helper returns a `WorkoutFormSeed` for all three entry points.
+
+**Implementation details**
+- Create one loader that encapsulates auth, ownership checks, workout query, and conversion into `WorkoutDraft`.
+- Create one transform for blank create.
+- Create one transform for edit.
+- Create one transform for duplicate that:
+  - sets the copied workout name
+  - sets today’s date using one shared helper
+  - clears notes and duration
+  - clears set values in `initialValues`
+  - preserves prior set values in `templateValuesByExerciseName`
+
+**Acceptance criteria**
+- [app/workouts/(form)/create/page.tsx](/Users/kevintatooles/Desktop/Projects/next-fitness-tracker/app/workouts/(form)/create/page.tsx), [app/workouts/(form)/edit/[id]/page.tsx](/Users/kevintatooles/Desktop/Projects/next-fitness-tracker/app/workouts/(form)/edit/[id]/page.tsx), and [app/workouts/(form)/duplicate/[id]/page.tsx](/Users/kevintatooles/Desktop/Projects/next-fitness-tracker/app/workouts/(form)/duplicate/[id]/page.tsx) become thin wrappers around the shared helper.
+- Edit and duplicate no longer duplicate auth/query/transform logic.
+- The create and duplicate flows use the same “today” defaulting logic.
+
+---
+
+### 3. Unify client save logic behind one abstraction
+Replace `createWorkout` and `updateWorkout` with one save layer that branches internally based on `persistMode`.
+
+**Implementation details**
+- Add a dedicated `saveWorkout` helper or `useWorkoutSave` hook in the form area.
+- Keep shared fetch setup, headers, error handling, and response parsing in one place.
+- Return normalized results:
+  - create returns the new `workoutId`
+  - update returns the existing `workoutId`
+- Keep toast behavior centralized in the save layer.
+
+**Acceptance criteria**
+- `onSubmit` has one save call, not separate POST/PATCH branches.
+- Save failure handling does not depend on object identity.
+- The form code clearly separates “save” from “what to do after save”.
+
+---
+
+### 4. Eliminate the page turn after create or duplicate save
+After a successful create/duplicate `POST`, keep the current form mounted, promote it into update mode locally, and replace the URL without a route transition.
+
+**Implementation details**
+- On successful first save:
+  - store returned `workoutId` in local state
+  - switch local `persistMode` from `"create"` to `"update"`
+  - call `reset(submittedValues)` to clear dirty state
+  - clear duplicate-only template hints if they are no longer needed
+  - call `window.history.replaceState(window.history.state, "", \`/workouts/edit/${workoutId}\`)`
+- Do not call `router.push(...)` after create.
+- Keep the form header/status mounted through the transition.
+
+**Acceptance criteria**
+- Saving in create or duplicate mode does not visibly navigate away or remount the page.
+- After first save, subsequent saves use `PATCH`.
+- Refreshing the browser after first save lands on the canonical edit route.
+
+---
+
+### 5. Switch RHF ownership to `defaultValues + reset`
+Stop using `useForm({ values })` and let RHF own form state after mount.
+
+**Implementation details**
+- Initialize the form with `defaultValues: normalizedInitialValues`.
+- Use a controlled `useEffect` + `reset(...)` only when the input seed intentionally changes.
+- Keep normalization in one place before RHF initialization.
+
+**Acceptance criteria**
+- [workout-form.tsx](/Users/kevintatooles/Desktop/Projects/next-fitness-tracker/components/workout-form/workout-form.tsx) no longer passes `values` into `useForm`.
+- Dirty state behaves predictably before and after save.
+- The form does not need prop-identity tricks to preserve user input.
+
+---
+
+### 6. Replace token-based save failure logic with explicit save state
+Remove `failedWorkoutValueToken` and the subscription-based failure reset behavior. Use a simple explicit save state and last-success flow.
+
+**Implementation details**
+- Track `saveState: "idle" | "saving" | "saved" | "failed"`.
+- Derive the header badge from `persistMode`, `isDirty`, and `saveState`.
+- On input changes after a failed save, clear only the `failed` state, not the form itself.
+- Do not subscribe to form events just to clear save errors.
+
+**Acceptance criteria**
+- [workout-form.tsx](/Users/kevintatooles/Desktop/Projects/next-fitness-tracker/components/workout-form/workout-form.tsx) no longer compares form objects for failure state.
+- Save status logic is readable from state alone.
+- The save-status header still shows correct behavior for create, duplicate, edit, saving, saved, and failed states.
+
+---
+
+### 7. Move exercise-name watching to row scope
+Remove the root `useWatch("exercises")` and watch only the exercise name required by each row.
+
+**Implementation details**
+- Move `useWatch({ name: \`exercises.${index}.name\` })` into [exercise-item.tsx](/Users/kevintatooles/Desktop/Projects/next-fitness-tracker/components/workout-form/exercise-item.tsx).
+- Pass only stable props from the parent list.
+- Keep `useFieldArray` at the root for exercise rows.
+
+**Acceptance criteria**
+- [workout-form.tsx](/Users/kevintatooles/Desktop/Projects/next-fitness-tracker/components/workout-form/workout-form.tsx) no longer watches the entire exercise array.
+- Editing a set in one exercise does not rerender all exercise rows just to update row names.
+- Exercise actions and placeholder logic still receive the correct current exercise name.
+
+---
+
+### 8. Precompute duplicate placeholder lookup data
+Stop doing repeated `placeholderValues?.find(...)` calls inside each set field render.
+
+**Implementation details**
+- Build `templateValuesByExerciseName` once in the server seed helper or once in the form component with `useMemo`.
+- Pass the matched template exercise directly into [form-sets.tsx](/Users/kevintatooles/Desktop/Projects/next-fitness-tracker/components/workout-form/form-sets.tsx) for the current row.
+- Preserve current behavior where duplicate shows prior set values only as placeholders.
+
+**Acceptance criteria**
+- [form-sets.tsx](/Users/kevintatooles/Desktop/Projects/next-fitness-tracker/components/workout-form/form-sets.tsx) does not search the full placeholder array from each input render.
+- Duplicate placeholders still match the selected exercise and set index correctly.
+- The new placeholder prop shape is direct and row-local.
+
+---
+
+### 9. Replace unnecessary `Controller` usage with `register`
+Reduce RHF overhead by using `register` for plain text, textarea, and number inputs, while keeping `Controller` for controlled widgets like the exercise selector.
+
+**Implementation details**
+- Keep `Controller` for:
+  - exercise selector
+  - any field that requires value transformation beyond native input behavior
+- Convert straightforward inputs in:
+  - [workout-form-header.tsx](/Users/kevintatooles/Desktop/Projects/next-fitness-tracker/components/workout-form/workout-form-header.tsx)
+  - [form-sets.tsx](/Users/kevintatooles/Desktop/Projects/next-fitness-tracker/components/workout-form/form-sets.tsx)
+  - duration field in [workout-form.tsx](/Users/kevintatooles/Desktop/Projects/next-fitness-tracker/components/workout-form/workout-form.tsx)
+- For `durationMinutes`, use RHF’s supported transformation approach consistently so `null` remains valid.
+
+**Acceptance criteria**
+- Most plain inputs use `register`.
+- The selector still works as a controlled component.
+- Validation and error rendering remain unchanged from the user’s perspective.
+
+---
+
+### 10. Centralize “today” date defaulting
+Create one helper for “today in workout date format” and use it in both blank create and duplicate seed generation.
+
+**Implementation details**
+- Put the helper in the shared form model/seed module.
+- Use the same date source and formatting rule for all create-like flows.
+- Do not keep separate client and server implementations.
+
+**Acceptance criteria**
+- There is one canonical helper for default workout dates.
+- Blank create and duplicate generate the same date for the same request context.
+- No route or component computes its own “today” string ad hoc.
+
+---
+
+### 11. Improve exercise options loading
+Move exercise-name fetching out of the form-mount effect and into a shared, predictable data-loading path.
+
+**Implementation details**
+- Preferred approach: load exercise names on the server alongside the form seed and pass them as props.
+- If server loading is not practical in the same pass, add a cached client fetch layer with explicit error handling.
+- Do not leave raw `fetch("/api/exercises")` in a mount-only effect without response checks.
+
+**Acceptance criteria**
+- The form does not issue an uncached “fire and forget” exercise-options request on every mount.
+- Error handling is explicit.
+- Exercise selector options are available consistently across create, edit, and duplicate.
+
+---
+
+### 12. Add focused tests for seed building, save promotion, and status transitions
+Expand test coverage around the new form architecture instead of only testing route handlers.
+
+**Implementation details**
+- Add Vitest unit tests for the shared seed builder:
+  - blank create seed
+  - edit seed
+  - duplicate seed
+  - duplicate placeholder generation
+  - today-date helper behavior
+- Add component or hook tests for the client save flow:
+  - create success promotes to update mode
+  - URL is replaced without push navigation
+  - subsequent save uses update mode
+  - failed save sets `failed` state
+  - successful save resets dirty state
+- Keep existing route tests in [tests/routes/workouts-routes.test.ts](/Users/kevintatooles/Desktop/Projects/next-fitness-tracker/tests/routes/workouts-routes.test.ts).
+
+**Acceptance criteria**
+- New unit tests cover seed generation for all entry modes.
+- New client-side tests cover save promotion and status transitions.
+- Existing route tests still pass unchanged or with minimal fixture updates.
+
+---
+
+### 13. Track a follow-up for diff-based PATCH updates
+Keep the current full rewrite update strategy for now, but record a follow-up issue for stable IDs and diffed updates.
+
+**Implementation details**
+- Do not implement this in the same refactor.
+- Document the reasons to defer:
+  - stable child IDs
+  - per-set metadata/history
+  - reduced transaction cost on large workouts
+  - better compatibility with future concurrent edits
+
+**Acceptance criteria**
+- The current refactor does not attempt to solve diff-based persistence.
+- The follow-up issue clearly states trigger conditions for revisiting the PATCH strategy.
+
+## Test Cases And Scenarios
+
+### Seed generation
+- Create route returns a blank draft with one empty exercise and one empty set.
+- Edit route returns the existing workout as-is.
+- Duplicate route returns:
+  - copied name
+  - today’s date
+  - empty notes and duration
+  - cleared set values in the editable draft
+  - original set values only in template hints
+
+### Save behavior
+- Create save uses `POST` and receives a `workoutId`.
+- Duplicate save uses `POST` and receives a `workoutId`.
+- Edit save uses `PATCH`.
+- After create/duplicate success:
+  - form stays mounted
+  - URL changes to `/workouts/edit/:id`
+  - mode becomes update
+  - dirty state resets
+  - another save uses `PATCH`
+
+### Save status
+- New create/duplicate form shows “not saved”.
+- Dirty edit form shows “unsaved changes”.
+- During any save, status shows “saving”.
+- After update success, status shows “saved”.
+- After failure, status shows “save failed”.
+- Editing after a failure clears failed state and returns to unsaved/idle behavior.
+
+### Performance-sensitive scenarios
+- Editing one set in a large workout does not rerender the entire exercise list due to a root `useWatch`.
+- Duplicate placeholder lookup is O(1) or row-local, not repeated full-array scans per input.
+- Exercise selector options load once per form seed path, not once per mount effect without cache.
+
+### Regression scenarios
+- Duplicate placeholders still appear correctly in set inputs.
+- Exercise history modal still works with current row name.
+- Save button disabling and status badge behavior remain correct.
+- Refresh after first create/duplicate save opens the canonical edit route successfully.
+
+## Delivery Notes
+- Implement Steps 1 through 6 as the core architecture and UX milestone.
+- Implement Steps 7 through 11 as the performance and cleanup milestone.
+- Implement Step 12 in the same PR as the corresponding architecture changes where possible.
+- Keep Step 13 as a separate follow-up GitHub issue, not part of the main refactor.


### PR DESCRIPTION
## Summary
- Centralized workout form seed building for create, edit, and duplicate flows in shared server-side model code.
- Extracted save logic into a single `saveWorkout` client helper and updated the form to use in-place URL replacement after a successful create.
- Consolidated form draft/template types and moved duplicate placeholder handling into the shared workout form model.
- Preserved workout form state across rerenders and kept edit mode stable after successful saves.
- Added/updated tests covering form model behavior, save behavior, and promotion from create to edit URL state.

## Testing
- `vitest` unit tests added for `components/workout-form/form-model.ts`.
- `vitest` unit tests added for `components/workout-form/save-workout.ts`.
- `vitest` component tests added for workout form promotion and URL replacement behavior.
- Not run: full application test suite or manual browser validation in this workspace.