### PR TITLE
Improve custom exercise creation UX

### DIFF
--- a/components/workout-form/exercise-selector.tsx
+++ b/components/workout-form/exercise-selector.tsx
@@ -47,16 +47,15 @@ export default function ExerciseSelector({
     trimmedSearchValue.length > 0 && !hasExactExistingMatch;
 
   function handleOpenChange(nextOpen: boolean) {
-    setOpen(nextOpen);
-
-    if (!nextOpen) {
+    if (nextOpen) {
       setSearchValue("");
     }
+
+    setOpen(nextOpen);
   }
 
   function handleExerciseSelect(nextValue: string) {
     onChange(nextValue);
-    setSearchValue("");
     setOpen(false);
   }
 

--- a/components/workout-form/exercise-selector.tsx
+++ b/components/workout-form/exercise-selector.tsx
@@ -31,9 +31,37 @@ export default function ExerciseSelector({
   const [open, setOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
   const displayValue = value || "Select exercise";
+  const trimmedSearchValue = searchValue.trim();
+  const normalizedSearchValue = trimmedSearchValue.toLocaleLowerCase();
+  const filteredExercises =
+    normalizedSearchValue === ""
+      ? exercises
+      : exercises.filter((exercise) =>
+          exercise.toLocaleLowerCase().includes(normalizedSearchValue),
+        );
+  const hasExactExistingMatch = exercises.some(
+    (exercise) =>
+      exercise.trim().toLocaleLowerCase() === normalizedSearchValue,
+  );
+  const shouldShowCreateOption =
+    trimmedSearchValue.length > 0 && !hasExactExistingMatch;
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+
+    if (!nextOpen) {
+      setSearchValue("");
+    }
+  }
+
+  function handleExerciseSelect(nextValue: string) {
+    onChange(nextValue);
+    setSearchValue("");
+    setOpen(false);
+  }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
           variant="outline"
@@ -50,35 +78,34 @@ export default function ExerciseSelector({
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-full p-0" align="start">
-        <Command>
+        <Command shouldFilter={false}>
           <CommandInput
-            placeholder="Search exercise..."
+            placeholder="Search or add exercise..."
             className="h-11 text-base"
             onInput={(e) => setSearchValue(e.currentTarget.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && searchValue.trim() !== "") {
-                e.preventDefault();
-                onChange(searchValue);
-                setOpen(false);
-              }
-            }}
           />
           <CommandList>
-            <CommandEmpty>No exercise found.</CommandEmpty>
+            <CommandEmpty>No matching exercises.</CommandEmpty>
             <CommandGroup>
-              {exercises.map((exercise) => (
+              {filteredExercises.map((exercise) => (
                 <CommandItem
                   value={exercise}
                   key={exercise}
-                  onSelect={() => {
-                    onChange(exercise);
-                    setOpen(false);
-                  }}
+                  onSelect={() => handleExerciseSelect(exercise)}
                   className="hover:bg-primary/10 cursor-pointer text-base transition-colors"
                 >
                   {exercise}
                 </CommandItem>
               ))}
+              {shouldShowCreateOption && (
+                <CommandItem
+                  value={trimmedSearchValue}
+                  onSelect={() => handleExerciseSelect(trimmedSearchValue)}
+                  className="hover:bg-primary/10 cursor-pointer text-base transition-colors"
+                >
+                  Add &quot;{trimmedSearchValue}&quot;
+                </CommandItem>
+              )}
             </CommandGroup>
           </CommandList>
         </Command>

--- a/tests/workout-form/exercise-selector.test.tsx
+++ b/tests/workout-form/exercise-selector.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ExerciseSelector from "@/components/workout-form/exercise-selector";
+
+describe("ExerciseSelector", () => {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  globalThis.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  async function renderSelector() {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <ExerciseSelector
+        value=""
+        onChange={onChange}
+        exercises={["Bench Press", "Overhead Press"]}
+      />,
+    );
+
+    const trigger = screen.getByTitle("Select exercise");
+    await user.click(trigger);
+
+    const input = await screen.findByPlaceholderText("Search or add exercise...");
+
+    return { user, onChange, input, trigger };
+  }
+
+  function queryCreateOption(value: string) {
+    return (
+      screen.queryAllByRole("option", {
+        name: `Add "${value}"`,
+        hidden: true,
+      })[0] ?? null
+    );
+  }
+
+  it("renders existing exercises and selects one", async () => {
+    const { user, onChange } = await renderSelector();
+
+    await user.click(screen.getByText("Bench Press"));
+
+    expect(onChange).toHaveBeenCalledWith("Bench Press");
+  });
+
+  it('shows an add option for a non-empty custom value', async () => {
+    const { user, input } = await renderSelector();
+
+    await user.type(input, "Romanian Deadlift");
+
+    await waitFor(() => {
+      expect(queryCreateOption("Romanian Deadlift")).toBeTruthy();
+    });
+  });
+
+  it("does not show an add option for whitespace-only input", async () => {
+    const { user, input } = await renderSelector();
+
+    await user.type(input, "   ");
+
+    await waitFor(() => {
+      expect(queryCreateOption("")).toBeNull();
+      expect(
+        screen.queryByText((_, node) => {
+          return node?.textContent?.startsWith('Add "') ?? false;
+        }),
+      ).toBeNull();
+    });
+  });
+
+  it("suppresses add when the typed value matches an existing exercise ignoring case and surrounding spaces", async () => {
+    const { user, input } = await renderSelector();
+
+    await user.type(input, " bench press ");
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText((_, node) => {
+          return node?.textContent?.startsWith('Add "') ?? false;
+        }),
+      ).toBeNull();
+    });
+  });
+
+  it("shows both partial matches and the add option for non-exact input", async () => {
+    const { user, input } = await renderSelector();
+
+    await user.type(input, "Bench");
+
+    expect(await screen.findByText("Bench Press")).toBeTruthy();
+    expect(screen.getByText('Add "Bench"')).toBeTruthy();
+  });
+
+  it("selecting the add option passes the trimmed custom value", async () => {
+    const { user, onChange, input } = await renderSelector();
+
+    await user.type(input, "  Romanian Deadlift  ");
+    await waitFor(() => {
+      expect(queryCreateOption("Romanian Deadlift")).toBeTruthy();
+    });
+    await user.click(queryCreateOption("Romanian Deadlift")!);
+
+    expect(onChange).toHaveBeenCalledWith("Romanian Deadlift");
+  });
+
+  it("clears the prior search when the popover closes and reopens", async () => {
+    const { user, input, trigger } = await renderSelector();
+
+    await user.type(input, "Romanian Deadlift");
+    await user.click(trigger);
+    await user.click(trigger);
+
+    await screen.findByPlaceholderText("Search or add exercise...");
+
+    await waitFor(() => {
+      expect(queryCreateOption("Romanian Deadlift")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add an explicit `Add "…"` option for custom exercise names
- suppress duplicate create prompts with trim + case-insensitive matching
- keep the filtered list stable while the selector closes to avoid flashing

Closes #118