### PR TITLE
Add workout superset support

### DIFF
--- a/app/api/export/route.ts
+++ b/app/api/export/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/db/drizzle";
 import { Workout } from "@/lib/types";
 import { NextRequest } from "next/server";
 import { jsonError, requireUserId } from "@/lib/api/route-helpers";
+import { groupExercisesForDisplay } from "@/lib/superset-utils";
 
 const EXPORT_FORMATS = {
   xlsx: {
@@ -55,13 +56,19 @@ export async function GET(request: NextRequest) {
   const input = [] as string[][];
   for (const workout of data) {
     input.push([workout.name]);
-    for (const exercise of workout.exercises) {
-      input.push([exercise.name]);
-      for (const set of exercise.sets) {
-        input.push([set.reps, set.weight]);
+    for (const block of groupExercisesForDisplay(workout.exercises)) {
+      if (block.kind === "superset") {
+        input.push(["Superset"]);
       }
-      input.push([exercise.notes]);
-      input.push([]);
+
+      for (const exercise of block.exercises) {
+        input.push([exercise.name]);
+        for (const set of exercise.sets) {
+          input.push([set.reps, set.weight]);
+        }
+        input.push([exercise.notes]);
+        input.push([]);
+      }
     }
     input.push([]);
     input.push([]);

--- a/app/api/workouts/[id]/route.ts
+++ b/app/api/workouts/[id]/route.ts
@@ -153,6 +153,7 @@ export async function PATCH(
             workoutId,
             name: exerciseData.name,
             notes: exerciseData.notes,
+            supersetGroupId: exerciseData.supersetGroupId,
           })
           .returning();
 

--- a/app/api/workouts/route.ts
+++ b/app/api/workouts/route.ts
@@ -48,6 +48,7 @@ export async function POST(request: NextRequest) {
             workoutId: newWorkout.id,
             name: exerciseData.name,
             notes: exerciseData.notes,
+            supersetGroupId: exerciseData.supersetGroupId,
           })
           .returning();
 

--- a/components/workout-form/exercise-actions-menu.tsx
+++ b/components/workout-form/exercise-actions-menu.tsx
@@ -4,6 +4,8 @@ import {
   ArrowDown,
   ArrowUp,
   History,
+  Link2,
+  Link2Off,
   MoreVertical,
   Trash2,
 } from "lucide-react";
@@ -21,8 +23,14 @@ interface ExerciseActionsMenuProps {
   onDelete: () => void;
   onMoveUp: () => void;
   onMoveDown: () => void;
+  onStartSupersetWithNext: () => void;
+  onJoinPreviousSuperset: () => void;
+  onRemoveFromSuperset: () => void;
   isFirst: boolean;
   isLast: boolean;
+  canStartSupersetWithNext: boolean;
+  canJoinPreviousSuperset: boolean;
+  isInSuperset: boolean;
 }
 
 export default function ExerciseActionsMenu({
@@ -31,8 +39,14 @@ export default function ExerciseActionsMenu({
   onDelete,
   onMoveUp,
   onMoveDown,
+  onStartSupersetWithNext,
+  onJoinPreviousSuperset,
+  onRemoveFromSuperset,
   isFirst,
   isLast,
+  canStartSupersetWithNext,
+  canJoinPreviousSuperset,
+  isInSuperset,
 }: ExerciseActionsMenuProps) {
   return (
     <DropdownMenu>
@@ -59,6 +73,24 @@ export default function ExerciseActionsMenu({
           <ArrowDown />
           Move Down
         </DropdownMenuItem>
+        {canStartSupersetWithNext ? (
+          <DropdownMenuItem onClick={onStartSupersetWithNext}>
+            <Link2 />
+            Start Superset With Next
+          </DropdownMenuItem>
+        ) : null}
+        {canJoinPreviousSuperset ? (
+          <DropdownMenuItem onClick={onJoinPreviousSuperset}>
+            <Link2 />
+            Join Previous Superset
+          </DropdownMenuItem>
+        ) : null}
+        {isInSuperset ? (
+          <DropdownMenuItem onClick={onRemoveFromSuperset}>
+            <Link2Off />
+            Remove From Superset
+          </DropdownMenuItem>
+        ) : null}
         <DropdownMenuItem variant="destructive" onClick={onDelete}>
           <Trash2 />
           Delete Exercise

--- a/components/workout-form/exercise-item.tsx
+++ b/components/workout-form/exercise-item.tsx
@@ -19,8 +19,14 @@ interface ExerciseItemProps {
   onRemove: () => void;
   onMoveUp: () => void;
   onMoveDown: () => void;
+  onStartSupersetWithNext: () => void;
+  onJoinPreviousSuperset: () => void;
+  onRemoveFromSuperset: () => void;
   isFirst: boolean;
   isLast: boolean;
+  canStartSupersetWithNext: boolean;
+  canJoinPreviousSuperset: boolean;
+  isInSuperset: boolean;
   workoutId?: number;
   templateExercise?: ExerciseTemplateValues;
 }
@@ -34,8 +40,14 @@ export default function ExerciseItem({
   onRemove,
   onMoveUp,
   onMoveDown,
+  onStartSupersetWithNext,
+  onJoinPreviousSuperset,
+  onRemoveFromSuperset,
   isFirst,
   isLast,
+  canStartSupersetWithNext,
+  canJoinPreviousSuperset,
+  isInSuperset,
   workoutId,
   templateExercise,
 }: ExerciseItemProps) {
@@ -59,8 +71,14 @@ export default function ExerciseItem({
                   onDelete={onRemove}
                   onMoveUp={onMoveUp}
                   onMoveDown={onMoveDown}
+                  onStartSupersetWithNext={onStartSupersetWithNext}
+                  onJoinPreviousSuperset={onJoinPreviousSuperset}
+                  onRemoveFromSuperset={onRemoveFromSuperset}
                   isFirst={isFirst}
                   isLast={isLast}
+                  canStartSupersetWithNext={canStartSupersetWithNext}
+                  canJoinPreviousSuperset={canJoinPreviousSuperset}
+                  isInSuperset={isInSuperset}
                 />
               </div>
               {fieldState.invalid && <FieldError errors={[fieldState.error]} />}

--- a/components/workout-form/form-model.ts
+++ b/components/workout-form/form-model.ts
@@ -28,6 +28,7 @@ function toWorkoutDraft(workout: Workout): WorkoutDraft {
     exercises: workout.exercises.map((exercise) => ({
       name: exercise.name,
       notes: exercise.notes,
+      supersetGroupId: exercise.supersetGroupId,
       sets: exercise.sets.map((set) => ({
         reps: set.reps,
         weight: set.weight,
@@ -46,6 +47,7 @@ function toDuplicateWorkoutDraft(workout: Workout): WorkoutDraft {
     exercises: workout.exercises.map((exercise) => ({
       name: exercise.name,
       notes: "",
+      supersetGroupId: exercise.supersetGroupId,
       sets: exercise.sets.map((set) => ({
         reps: set.reps,
         weight: set.weight,
@@ -148,6 +150,7 @@ export function buildBlankWorkoutFormSeed(
         {
           name: "",
           notes: "",
+          supersetGroupId: null,
           sets: [{ weight: "", reps: "", rpe: "" }],
         },
       ],

--- a/components/workout-form/workout-form.tsx
+++ b/components/workout-form/workout-form.tsx
@@ -362,9 +362,9 @@ export default function WorkoutForm(props: WorkoutFormProps) {
             return (
               <div
                 key={`superset-${renderExercises[block.startIndex]?.id ?? block.startIndex}`}
-                className="space-y-3 rounded-xl border border-dashed p-3"
+                className="space-y-3 rounded-xl border border-dashed border-yellow-500/40 bg-yellow-500/5 p-3 dark:border-yellow-400/35 dark:bg-yellow-400/5"
               >
-                <div className="text-muted-foreground text-xs font-semibold uppercase tracking-[0.2em]">
+                <div className="text-xs font-semibold uppercase tracking-[0.2em] text-yellow-700 dark:text-yellow-300">
                   Superset
                 </div>
                 <div className="space-y-4">{blockContent}</div>

--- a/components/workout-form/workout-form.tsx
+++ b/components/workout-form/workout-form.tsx
@@ -26,6 +26,14 @@ import {
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { saveWorkout } from "@/components/workout-form/save-workout";
+import {
+  groupExercisesForDisplay,
+  joinSupersetWithPrevious,
+  moveExerciseBlock,
+  removeExerciseAtIndex,
+  removeExerciseFromSuperset,
+  startSupersetWithNext,
+} from "@/lib/superset-utils";
 
 const cloneWorkoutForm = (values: WorkoutDraft) => structuredClone(values);
 const getBrowserTodayDate = () => new Date().toLocaleDateString("en-CA");
@@ -148,7 +156,7 @@ export default function WorkoutForm(props: WorkoutFormProps) {
     subscribe,
     formState: { isDirty, isSubmitting },
   } = form;
-  const { fields, append, remove, move } = useFieldArray({
+  const { fields, append, replace } = useFieldArray({
     control,
     name: "exercises",
   });
@@ -156,6 +164,13 @@ export default function WorkoutForm(props: WorkoutFormProps) {
     control,
     name: "exercises",
   });
+  const currentExercises = watchedExercises ?? getValues("exercises");
+  const renderExercises = fields.map((field, index) => ({
+    id: field.id,
+    name: currentExercises[index]?.name ?? "",
+    supersetGroupId: currentExercises[index]?.supersetGroupId ?? null,
+  }));
+  const exerciseBlocks = groupExercisesForDisplay(renderExercises);
   const saveStatus = getSaveStatus({
     persistMode: formSession.persistMode,
     hasSaveFailed,
@@ -246,6 +261,12 @@ export default function WorkoutForm(props: WorkoutFormProps) {
     }
   };
 
+  const replaceExercises = (exercises: WorkoutDraft["exercises"]) => {
+    replace(exercises);
+  };
+
+  const createSupersetGroupId = () => globalThis.crypto.randomUUID();
+
   return (
     <form noValidate onSubmit={handleSubmit(onSubmit)} aria-busy={isSubmitting}>
       <WorkoutFormActionHeader saveStatus={saveStatus} />
@@ -256,30 +277,98 @@ export default function WorkoutForm(props: WorkoutFormProps) {
         <FieldSet>
           <FieldLegend>Exercises</FieldLegend>
 
-          {fields.map((field, index) => {
-            const exerciseName = watchedExercises?.[index]?.name || "";
-            const templateExercise = getTemplateExerciseByName({
-              exerciseName,
-              templateValuesByExerciseName:
-                formSession.templateValuesByExerciseName,
+          {exerciseBlocks.map((block) => {
+            const blockContent = block.exercises.map((_, offset) => {
+              const index = block.startIndex + offset;
+              const field = fields[index];
+              const exerciseName = renderExercises[index]?.name ?? "";
+              const exerciseGroupId =
+                renderExercises[index]?.supersetGroupId ?? null;
+              const templateExercise = getTemplateExerciseByName({
+                exerciseName,
+                templateValuesByExerciseName:
+                  formSession.templateValuesByExerciseName,
+              });
+
+              if (!field) {
+                return null;
+              }
+
+              return (
+                <ExerciseItem
+                  key={field.id}
+                  index={index}
+                  control={control}
+                  getValues={getValues}
+                  exercises={formSession.exerciseNames}
+                  exerciseName={exerciseName}
+                  onRemove={() =>
+                    replaceExercises(
+                      removeExerciseAtIndex(getValues("exercises"), index),
+                    )
+                  }
+                  onMoveUp={() =>
+                    replaceExercises(
+                      moveExerciseBlock(getValues("exercises"), index, "up"),
+                    )
+                  }
+                  onMoveDown={() =>
+                    replaceExercises(
+                      moveExerciseBlock(getValues("exercises"), index, "down"),
+                    )
+                  }
+                  onStartSupersetWithNext={() =>
+                    replaceExercises(
+                      startSupersetWithNext(
+                        getValues("exercises"),
+                        index,
+                        createSupersetGroupId(),
+                      ),
+                    )
+                  }
+                  onJoinPreviousSuperset={() =>
+                    replaceExercises(
+                      joinSupersetWithPrevious(
+                        getValues("exercises"),
+                        index,
+                        createSupersetGroupId,
+                      ),
+                    )
+                  }
+                  onRemoveFromSuperset={() =>
+                    replaceExercises(
+                      removeExerciseFromSuperset(getValues("exercises"), index),
+                    )
+                  }
+                  isFirst={block.startIndex === 0}
+                  isLast={block.endIndex === renderExercises.length - 1}
+                  canStartSupersetWithNext={
+                    index < renderExercises.length - 1 &&
+                    !exerciseGroupId &&
+                    !renderExercises[index + 1]?.supersetGroupId
+                  }
+                  canJoinPreviousSuperset={index > 0 && !exerciseGroupId}
+                  isInSuperset={Boolean(exerciseGroupId)}
+                  workoutId={formSession.workoutId}
+                  templateExercise={templateExercise}
+                />
+              );
             });
 
+            if (block.kind === "single") {
+              return blockContent;
+            }
+
             return (
-              <ExerciseItem
-                key={field.id}
-                index={index}
-                control={control}
-                getValues={getValues}
-                exercises={formSession.exerciseNames}
-                exerciseName={exerciseName}
-                onRemove={() => remove(index)}
-                onMoveUp={() => move(index, index - 1)}
-                onMoveDown={() => move(index, index + 1)}
-                isFirst={index === 0}
-                isLast={index === fields.length - 1}
-                workoutId={formSession.workoutId}
-                templateExercise={templateExercise}
-              />
+              <div
+                key={`superset-${renderExercises[block.startIndex]?.id ?? block.startIndex}`}
+                className="space-y-3 rounded-xl border border-dashed p-3"
+              >
+                <div className="text-muted-foreground text-xs font-semibold uppercase tracking-[0.2em]">
+                  Superset
+                </div>
+                <div className="space-y-4">{blockContent}</div>
+              </div>
             );
           })}
 
@@ -290,6 +379,7 @@ export default function WorkoutForm(props: WorkoutFormProps) {
               append({
                 name: "",
                 notes: "",
+                supersetGroupId: null,
                 sets: [{ weight: "", reps: "", rpe: "" }],
               })
             }

--- a/components/workouts.tsx
+++ b/components/workouts.tsx
@@ -28,6 +28,7 @@ import ExerciseInstanceItem from "@/components/exercise/exercise-instance-item";
 import { Workout, WorkoutSummary } from "@/lib/types";
 import { formatDate, formatWorkoutDuration } from "@/lib/utils";
 import { copyWorkoutToClipboard } from "@/lib/workout-utils";
+import { groupExercisesForDisplay } from "@/lib/superset-utils";
 import { Copy, Files, Pencil, Trash2 } from "lucide-react";
 
 function getAccordionItemValue(workoutId: number) {
@@ -216,14 +217,35 @@ function WorkoutDetails({
         )}
         {!isLoading && !error && data ? (
           <div className="space-y-4">
-            {data.exercises.map((exercise) => (
-              <ExerciseInstanceItem
-                exercise={exercise}
-                showName={true}
-                showDate={false}
-                key={exercise.id}
-              />
-            ))}
+            {groupExercisesForDisplay(data.exercises).map((block) =>
+              block.kind === "superset" ? (
+                <div
+                  key={`superset-${block.startIndex}-${block.supersetGroupId}`}
+                  className="space-y-3 rounded-xl border border-dashed p-3"
+                >
+                  <div className="text-muted-foreground text-xs font-semibold uppercase tracking-[0.2em]">
+                    Superset
+                  </div>
+                  <div className="space-y-4">
+                    {block.exercises.map((exercise) => (
+                      <ExerciseInstanceItem
+                        exercise={exercise}
+                        showName={true}
+                        showDate={false}
+                        key={exercise.id}
+                      />
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <ExerciseInstanceItem
+                  exercise={block.exercises[0]}
+                  showName={true}
+                  showDate={false}
+                  key={block.exercises[0].id}
+                />
+              ),
+            )}
           </div>
         ) : null}
       </AccordionContent>

--- a/components/workouts.tsx
+++ b/components/workouts.tsx
@@ -221,9 +221,9 @@ function WorkoutDetails({
               block.kind === "superset" ? (
                 <div
                   key={`superset-${block.startIndex}-${block.supersetGroupId}`}
-                  className="space-y-3 rounded-xl border border-dashed p-3"
+                  className="space-y-3 rounded-xl border border-dashed border-yellow-500/40 bg-yellow-500/5 p-3 dark:border-yellow-400/35 dark:bg-yellow-400/5"
                 >
-                  <div className="text-muted-foreground text-xs font-semibold uppercase tracking-[0.2em]">
+                  <div className="text-xs font-semibold uppercase tracking-[0.2em] text-yellow-700 dark:text-yellow-300">
                     Superset
                   </div>
                   <div className="space-y-4">

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -24,6 +24,7 @@ export const exercise = sqliteTable(
     id: integer("id").primaryKey(),
     name: text("name", { length: 256 }).notNull(),
     notes: text("notes").notNull(),
+    supersetGroupId: text("superset_group_id"),
     workoutId: integer("workout_id")
       .references(() => workout.id, { onDelete: "cascade" })
       .notNull(),

--- a/docs/qa/2026-04-18-superset-issues.md
+++ b/docs/qa/2026-04-18-superset-issues.md
@@ -1,0 +1,51 @@
+# Superset QA Findings
+
+Date: 2026-04-18
+Environment: local app on `localhost:3000`, exercised in `Helium`
+
+## Summary
+
+Manual QA covered workout creation, edit, save, detail rendering, clipboard copy, and a subset of mutation flows for the new superset support.
+
+## Confirmed Passes
+
+- Creating a superset from the workout form works.
+- Joining an existing superset from the next exercise works.
+- Removing the middle member from a 3-exercise superset correctly clears the split group.
+- After the middle-removal flow, the preceding exercise regains `Start Superset With Next`.
+- Saved workout details render a single `Superset` block for contiguous grouped exercises.
+- Clipboard copy emits one `Superset` heading before grouped exercises.
+- Moving a grouped exercise down moves the whole contiguous block.
+
+## Confirmed Failures
+
+### Delete From Persisted Superset Can Crash Edit Form
+
+Reproduction:
+
+1. Open a saved workout in edit mode.
+2. Create or load a persisted 2-exercise superset.
+3. Open the exercise actions menu on one grouped exercise.
+4. Choose `Delete Exercise`.
+
+Observed result:
+
+- The edit page crashes with `TypeError: Cannot read properties of undefined (reading 'id')`.
+- The stack trace points to `components/workout-form/workout-form.tsx` during grouped block rendering.
+
+Notes:
+
+- This was reproduced against a live saved workout.
+- The failure happens after save/reload, so it is not limited to unsaved draft state.
+
+## Coverage Gaps Identified During QA
+
+- No automated component regression covering `Delete Exercise` for a grouped exercise in the persisted grouped render path.
+- No automated UI-level regression covering `Remove From Superset` on a larger saved group.
+- Export coverage exists, but the assertions should verify ordering and heading placement more explicitly.
+
+## Follow-Up
+
+- Add focused regression tests for grouped delete and remove flows.
+- Fix the grouped render/delete bug in `WorkoutForm`.
+- Re-run focused browser QA after the regression is covered automatically.

--- a/lib/superset-utils.ts
+++ b/lib/superset-utils.ts
@@ -184,7 +184,7 @@ export function moveExerciseBlock<T extends ExerciseWithSupersetGroup>(
 
   nextExercises.splice(insertionIndex, 0, ...block);
 
-  return nextExercises;
+  return normalizeSupersetGroups(nextExercises);
 }
 
 export function groupExercisesForDisplay<T extends ExerciseWithSupersetGroup>(

--- a/lib/superset-utils.ts
+++ b/lib/superset-utils.ts
@@ -169,6 +169,7 @@ export function moveExerciseBlock<T extends ExerciseWithSupersetGroup>(
 ): T[] {
   const nextExercises = cloneExercises(exercises);
   const { startIndex, endIndex } = getSupersetBlockRange(nextExercises, index);
+  const blockSize = endIndex - startIndex + 1;
 
   if (direction === "up" && startIndex === 0) {
     return nextExercises;
@@ -178,9 +179,15 @@ export function moveExerciseBlock<T extends ExerciseWithSupersetGroup>(
     return nextExercises;
   }
 
+  const adjacentBlockRange =
+    direction === "up"
+      ? getSupersetBlockRange(nextExercises, startIndex - 1)
+      : getSupersetBlockRange(nextExercises, endIndex + 1);
   const block = nextExercises.splice(startIndex, endIndex - startIndex + 1);
   const insertionIndex =
-    direction === "up" ? startIndex - 1 : startIndex + 1;
+    direction === "up"
+      ? adjacentBlockRange.startIndex
+      : adjacentBlockRange.endIndex - blockSize + 1;
 
   nextExercises.splice(insertionIndex, 0, ...block);
 

--- a/lib/superset-utils.ts
+++ b/lib/superset-utils.ts
@@ -1,0 +1,244 @@
+type ExerciseWithSupersetGroup = {
+  supersetGroupId: string | null;
+};
+
+export type ExerciseDisplayBlock<T extends ExerciseWithSupersetGroup> =
+  | {
+      kind: "single";
+      startIndex: number;
+      endIndex: number;
+      supersetGroupId: null;
+      exercises: T[];
+    }
+  | {
+      kind: "superset";
+      startIndex: number;
+      endIndex: number;
+      supersetGroupId: string;
+      exercises: T[];
+    };
+
+function cloneExercises<T>(exercises: T[]): T[] {
+  return structuredClone(exercises);
+}
+
+function normalizeSupersetGroups<T extends ExerciseWithSupersetGroup>(
+  exercises: T[],
+): T[] {
+  const validGroupIds = new Set<string>();
+  const invalidGroupIds = new Set<string>();
+
+  for (let index = 0; index < exercises.length; index += 1) {
+    const groupId = exercises[index]?.supersetGroupId;
+
+    if (!groupId) {
+      continue;
+    }
+
+    let endIndex = index;
+
+    while (endIndex + 1 < exercises.length && exercises[endIndex + 1]?.supersetGroupId === groupId) {
+      endIndex += 1;
+    }
+
+    const blockSize = endIndex - index + 1;
+
+    if (blockSize < 2 || validGroupIds.has(groupId)) {
+      invalidGroupIds.add(groupId);
+    } else if (!invalidGroupIds.has(groupId)) {
+      validGroupIds.add(groupId);
+    }
+
+    index = endIndex;
+  }
+
+  return exercises.map((exercise) => {
+    if (exercise.supersetGroupId && invalidGroupIds.has(exercise.supersetGroupId)) {
+      return {
+        ...exercise,
+        supersetGroupId: null,
+      };
+    }
+
+    return exercise;
+  });
+}
+
+function getSupersetBlockRange<T extends ExerciseWithSupersetGroup>(
+  exercises: T[],
+  index: number,
+) {
+  const groupId = exercises[index]?.supersetGroupId;
+
+  if (!groupId) {
+    return {
+      startIndex: index,
+      endIndex: index,
+    };
+  }
+
+  let startIndex = index;
+  let endIndex = index;
+
+  while (startIndex > 0 && exercises[startIndex - 1]?.supersetGroupId === groupId) {
+    startIndex -= 1;
+  }
+
+  while (
+    endIndex < exercises.length - 1 &&
+    exercises[endIndex + 1]?.supersetGroupId === groupId
+  ) {
+    endIndex += 1;
+  }
+
+  return {
+    startIndex,
+    endIndex,
+  };
+}
+
+export function startSupersetWithNext<T extends ExerciseWithSupersetGroup>(
+  exercises: T[],
+  index: number,
+  supersetGroupId: string,
+): T[] {
+  const nextExercises = cloneExercises(exercises);
+
+  if (!nextExercises[index + 1]) {
+    return nextExercises;
+  }
+
+  nextExercises[index].supersetGroupId = supersetGroupId;
+  nextExercises[index + 1].supersetGroupId = supersetGroupId;
+
+  return normalizeSupersetGroups(nextExercises);
+}
+
+export function joinSupersetWithPrevious<T extends ExerciseWithSupersetGroup>(
+  exercises: T[],
+  index: number,
+  createSupersetGroupId: () => string,
+): T[] {
+  const nextExercises = cloneExercises(exercises);
+  const previousExercise = nextExercises[index - 1];
+  const currentExercise = nextExercises[index];
+
+  if (!previousExercise || !currentExercise) {
+    return nextExercises;
+  }
+
+  const supersetGroupId =
+    previousExercise.supersetGroupId ?? createSupersetGroupId();
+
+  previousExercise.supersetGroupId = supersetGroupId;
+  currentExercise.supersetGroupId = supersetGroupId;
+
+  return normalizeSupersetGroups(nextExercises);
+}
+
+export function removeExerciseFromSuperset<T extends ExerciseWithSupersetGroup>(
+  exercises: T[],
+  index: number,
+): T[] {
+  const nextExercises = cloneExercises(exercises);
+
+  if (!nextExercises[index]) {
+    return nextExercises;
+  }
+
+  nextExercises[index].supersetGroupId = null;
+
+  return normalizeSupersetGroups(nextExercises);
+}
+
+export function removeExerciseAtIndex<T extends ExerciseWithSupersetGroup>(
+  exercises: T[],
+  index: number,
+): T[] {
+  const nextExercises = cloneExercises(exercises);
+
+  nextExercises.splice(index, 1);
+
+  return normalizeSupersetGroups(nextExercises);
+}
+
+export function moveExerciseBlock<T extends ExerciseWithSupersetGroup>(
+  exercises: T[],
+  index: number,
+  direction: "up" | "down",
+): T[] {
+  const nextExercises = cloneExercises(exercises);
+  const { startIndex, endIndex } = getSupersetBlockRange(nextExercises, index);
+
+  if (direction === "up" && startIndex === 0) {
+    return nextExercises;
+  }
+
+  if (direction === "down" && endIndex === nextExercises.length - 1) {
+    return nextExercises;
+  }
+
+  const block = nextExercises.splice(startIndex, endIndex - startIndex + 1);
+  const insertionIndex =
+    direction === "up" ? startIndex - 1 : startIndex + 1;
+
+  nextExercises.splice(insertionIndex, 0, ...block);
+
+  return nextExercises;
+}
+
+export function groupExercisesForDisplay<T extends ExerciseWithSupersetGroup>(
+  exercises: T[],
+): ExerciseDisplayBlock<T>[] {
+  const blocks: ExerciseDisplayBlock<T>[] = [];
+  let index = 0;
+
+  while (index < exercises.length) {
+    const exercise = exercises[index];
+    const supersetGroupId = exercise.supersetGroupId;
+
+    if (!supersetGroupId) {
+      blocks.push({
+        kind: "single",
+        startIndex: index,
+        endIndex: index,
+        supersetGroupId: null,
+        exercises: [exercise],
+      });
+      index += 1;
+      continue;
+    }
+
+    let endIndex = index;
+
+    while (
+      endIndex + 1 < exercises.length &&
+      exercises[endIndex + 1].supersetGroupId === supersetGroupId
+    ) {
+      endIndex += 1;
+    }
+
+    if (endIndex === index) {
+      blocks.push({
+        kind: "single",
+        startIndex: index,
+        endIndex: index,
+        supersetGroupId: null,
+        exercises: [exercise],
+      });
+      index += 1;
+      continue;
+    }
+
+    blocks.push({
+      kind: "superset",
+      startIndex: index,
+      endIndex,
+      supersetGroupId,
+      exercises: exercises.slice(index, endIndex + 1),
+    });
+    index = endIndex + 1;
+  }
+
+  return blocks;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -23,6 +23,7 @@ export interface ExerciseInstance {
   id: number;
   name: string;
   notes: string;
+  supersetGroupId: string | null;
   workoutId: number;
   sets: Set[];
   // It would make sense for ExerciseInstance to contain date :/
@@ -31,6 +32,7 @@ export interface ExerciseInstance {
 export interface ExerciseThin {
   name: string;
   notes: string;
+  supersetGroupId: string | null;
   sets: {
     weight: string;
     reps: string;
@@ -44,6 +46,7 @@ export interface DateExercise {
   id?: number | null;
   name?: string | null;
   notes?: string | null;
+  supersetGroupId?: string | null;
   workoutId?: number | null;
   workoutName?: string | null;
   sets: Set[];
@@ -74,24 +77,71 @@ const workoutDateSchema = z
   .min(1, "Workout date is required")
   .regex(/^\d{4}-\d{2}-\d{2}$/, "Workout date must be in YYYY-MM-DD format");
 
-export const workoutFormSchema = z.object({
-  date: workoutDateSchema,
-  name: z.string().min(1, "Workout name must be at least 1 character").max(50),
+const workoutExerciseSchema = z.object({
+  name: z.string().min(1, "Exercise name must be at least 1 character"),
   notes: z.string(),
-  durationMinutes: nullableDurationMinutesSchema,
-  exercises: z
+  supersetGroupId: z.string().trim().min(1).nullable(),
+  sets: z
     .object({
-      name: z.string().min(1, "Exercise name must be at least 1 character"),
-      notes: z.string(),
-      sets: z
-        .object({
-          weight: z.string(),
-          reps: z.string(),
-          rpe: z.string(),
-        })
-        .array(),
+      weight: z.string(),
+      reps: z.string(),
+      rpe: z.string(),
     })
     .array(),
 });
+
+function addSupersetValidation(
+  exercises: z.infer<typeof workoutExerciseSchema>[],
+  context: z.RefinementCtx,
+) {
+  const groupIndices = new Map<string, number[]>();
+
+  exercises.forEach((exercise, index) => {
+    if (!exercise.supersetGroupId) {
+      return;
+    }
+
+    const indices = groupIndices.get(exercise.supersetGroupId) ?? [];
+    indices.push(index);
+    groupIndices.set(exercise.supersetGroupId, indices);
+  });
+
+  for (const [supersetGroupId, indices] of groupIndices) {
+    if (indices.length < 2) {
+      context.addIssue({
+        code: "custom",
+        message: `Superset group "${supersetGroupId}" must include at least 2 exercises`,
+        path: ["exercises", indices[0], "supersetGroupId"],
+      });
+      continue;
+    }
+
+    for (let index = 1; index < indices.length; index += 1) {
+      if (indices[index] !== indices[index - 1] + 1) {
+        context.addIssue({
+          code: "custom",
+          message: `Superset group "${supersetGroupId}" exercises must stay adjacent`,
+          path: ["exercises", indices[index], "supersetGroupId"],
+        });
+        break;
+      }
+    }
+  }
+}
+
+export const workoutFormSchema = z
+  .object({
+    date: workoutDateSchema,
+    name: z
+      .string()
+      .min(1, "Workout name must be at least 1 character")
+      .max(50),
+    notes: z.string(),
+    durationMinutes: nullableDurationMinutesSchema,
+    exercises: workoutExerciseSchema.array(),
+  })
+  .superRefine(({ exercises }, context) => {
+    addSupersetValidation(exercises, context);
+  });
 
 export type TWorkoutFormSchema = z.infer<typeof workoutFormSchema>;

--- a/lib/workout-utils.ts
+++ b/lib/workout-utils.ts
@@ -56,6 +56,10 @@ export const copyWorkoutToClipboard = async (workout: Workout) => {
         text += "\n";
       });
 
+      if (block.kind === "superset") {
+        text += "End Superset\n";
+      }
+
       if (idx === blocks.length - 1) {
         text = text.trimEnd();
         return;

--- a/lib/workout-utils.ts
+++ b/lib/workout-utils.ts
@@ -1,6 +1,35 @@
 import { Workout, ExerciseInstance } from "@/lib/types";
 import { formatDate, formatWorkoutDuration } from "@/lib/utils";
+import { groupExercisesForDisplay } from "@/lib/superset-utils";
 import { toast } from "sonner";
+
+function formatExerciseText(exercise: ExerciseInstance) {
+  let text = `${exercise.name}\n`;
+
+  exercise.sets.forEach((set, setIdx) => {
+    text += `Set ${setIdx + 1}: `;
+
+    if (set.weight) {
+      text += `${set.weight} lbs`;
+    }
+
+    if (set.reps) {
+      text += ` x ${set.reps} reps`;
+    }
+
+    if (set.rpe) {
+      text += ` @ RPE ${set.rpe}`;
+    }
+
+    text += "\n";
+  });
+
+  if (exercise.notes && exercise.notes.trim()) {
+    text += `Notes: ${exercise.notes}\n`;
+  }
+
+  return text;
+}
 
 export const copyWorkoutToClipboard = async (workout: Workout) => {
   try {
@@ -15,37 +44,24 @@ export const copyWorkoutToClipboard = async (workout: Workout) => {
       text += `Notes: ${workout.notes}\n\n`;
     }
 
-    workout.exercises.forEach((exercise: ExerciseInstance, idx: number) => {
-      text += `${exercise.name}\n`;
+    const blocks = groupExercisesForDisplay(workout.exercises);
 
-      // Add sets
-      exercise.sets.forEach((set, setIdx) => {
-        text += `Set ${setIdx + 1}: `;
+    blocks.forEach((block, idx) => {
+      if (block.kind === "superset") {
+        text += "Superset\n";
+      }
 
-        if (set.weight) {
-          text += `${set.weight} lbs`;
-        }
-
-        if (set.reps) {
-          text += ` x ${set.reps} reps`;
-        }
-
-        if (set.rpe) {
-          text += ` @ RPE ${set.rpe}`;
-        }
-
+      block.exercises.forEach((exercise) => {
+        text += formatExerciseText(exercise);
         text += "\n";
       });
 
-      // Add notes after sets if they exist
-      if (exercise.notes && exercise.notes.trim()) {
-        text += `Notes: ${exercise.notes}\n`;
+      if (idx === blocks.length - 1) {
+        text = text.trimEnd();
+        return;
       }
 
-      // Add blank line between exercises (but not after the last one)
-      if (idx < workout.exercises.length - 1) {
-        text += "\n";
-      }
+      text += "\n";
     });
 
     // Copy to clipboard

--- a/migrations/0002_harsh_shiva.sql
+++ b/migrations/0002_harsh_shiva.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `exercise` ADD `superset_group_id` text;

--- a/migrations/meta/0002_snapshot.json
+++ b/migrations/meta/0002_snapshot.json
@@ -1,0 +1,217 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "512fd888-0fa3-47ed-800a-6006b91ba559",
+  "prevId": "d8831047-299f-429f-8b3d-082da36b098d",
+  "tables": {
+    "exercise": {
+      "name": "exercise",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superset_group_id": {
+          "name": "superset_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "exercise_workout_name_idx": {
+          "name": "exercise_workout_name_idx",
+          "columns": [
+            "workout_id",
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "exercise_workout_id_workout_id_fk": {
+          "name": "exercise_workout_id_workout_id_fk",
+          "tableFrom": "exercise",
+          "tableTo": "workout",
+          "columnsFrom": [
+            "workout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "set": {
+      "name": "set",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reps": {
+          "name": "reps",
+          "type": "text(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "text(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rpe": {
+          "name": "rpe",
+          "type": "text(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "set_exercise_id_id_idx": {
+          "name": "set_exercise_id_id_idx",
+          "columns": [
+            "exercise_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "set_exercise_id_exercise_id_fk": {
+          "name": "set_exercise_id_exercise_id_fk",
+          "tableFrom": "set",
+          "tableTo": "exercise",
+          "columnsFrom": [
+            "exercise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workout": {
+      "name": "workout",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workout_user_date_idx": {
+          "name": "workout_user_date_idx",
+          "columns": [
+            "user_id",
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776388599841,
       "tag": "0001_add_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1776546869558,
+      "tag": "0002_harsh_shiva",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/components/exercise-actions-menu.test.tsx
+++ b/tests/components/exercise-actions-menu.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    children: React.ReactNode;
+  }) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/exercise/exercise-history-modal", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+import ExerciseActionsMenu from "@/components/workout-form/exercise-actions-menu";
+
+describe("ExerciseActionsMenu", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the contextual superset actions for an ungrouped middle exercise", () => {
+    render(
+      <ExerciseActionsMenu
+        exerciseName="Bench Press"
+        onDelete={() => {}}
+        onMoveUp={() => {}}
+        onMoveDown={() => {}}
+        onStartSupersetWithNext={() => {}}
+        onJoinPreviousSuperset={() => {}}
+        onRemoveFromSuperset={() => {}}
+        isFirst={false}
+        isLast={false}
+        canStartSupersetWithNext={true}
+        canJoinPreviousSuperset={true}
+        isInSuperset={false}
+      />,
+    );
+
+    expect(screen.getByText("Start Superset With Next")).toBeTruthy();
+    expect(screen.getByText("Join Previous Superset")).toBeTruthy();
+    expect(screen.queryByText("Remove From Superset")).toBeNull();
+  });
+
+  it("shows remove from superset for grouped exercises and hides create actions", () => {
+    render(
+      <ExerciseActionsMenu
+        exerciseName="Bench Press"
+        onDelete={() => {}}
+        onMoveUp={() => {}}
+        onMoveDown={() => {}}
+        onStartSupersetWithNext={() => {}}
+        onJoinPreviousSuperset={() => {}}
+        onRemoveFromSuperset={() => {}}
+        isFirst={false}
+        isLast={false}
+        canStartSupersetWithNext={false}
+        canJoinPreviousSuperset={false}
+        isInSuperset={true}
+      />,
+    );
+
+    expect(screen.getByText("Remove From Superset")).toBeTruthy();
+    expect(screen.queryByText("Start Superset With Next")).toBeNull();
+    expect(screen.queryByText("Join Previous Superset")).toBeNull();
+  });
+
+  it("calls the matching superset callback when selected", () => {
+    const onStartSupersetWithNext = vi.fn();
+
+    render(
+      <ExerciseActionsMenu
+        exerciseName="Bench Press"
+        onDelete={() => {}}
+        onMoveUp={() => {}}
+        onMoveDown={() => {}}
+        onStartSupersetWithNext={onStartSupersetWithNext}
+        onJoinPreviousSuperset={() => {}}
+        onRemoveFromSuperset={() => {}}
+        isFirst={false}
+        isLast={false}
+        canStartSupersetWithNext={true}
+        canJoinPreviousSuperset={false}
+        isInSuperset={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Start Superset With Next"));
+
+    expect(onStartSupersetWithNext).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/components/workouts.test.tsx
+++ b/tests/components/workouts.test.tsx
@@ -192,8 +192,17 @@ const workoutDetailsFixture: Workout = {
       id: 10,
       name: "Bench Press",
       notes: "Paused",
+      supersetGroupId: "superset-a",
       workoutId: 1,
       sets: [{ id: 100, exerciseId: 10, weight: "225", reps: "5", rpe: "8" }],
+    },
+    {
+      id: 11,
+      name: "Chest Supported Row",
+      notes: "",
+      supersetGroupId: "superset-a",
+      workoutId: 1,
+      sets: [{ id: 101, exerciseId: 11, weight: "180", reps: "8", rpe: "8" }],
     },
   ],
 };
@@ -279,5 +288,20 @@ describe("Workouts", () => {
       expect(screen.getByText("Incline Press detail")).toBeTruthy();
     });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows a Superset heading once for adjacent grouped exercises", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <Workouts workouts={workoutSummaryFixture} />
+      </SWRConfig>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Push Day/i }));
+
+    expect(await screen.findByText("Superset")).toBeTruthy();
+    expect(screen.getAllByText(/detail$/)).toHaveLength(2);
   });
 });

--- a/tests/lib/superset-utils.test.ts
+++ b/tests/lib/superset-utils.test.ts
@@ -120,7 +120,7 @@ describe("superset utilities", () => {
     ]);
   });
 
-  it("clears a split superset when a standalone exercise moves into the middle of it", () => {
+  it("moves a standalone exercise past the entire adjacent superset block", () => {
     const updated = moveExerciseBlock(
       [
         { ...exercises[0], supersetGroupId: "superset-a" },
@@ -132,14 +132,48 @@ describe("superset utilities", () => {
     );
 
     expect(updated.map((exercise) => exercise.name)).toEqual([
-      "Bench Press",
       "Bicep Curl",
+      "Bench Press",
       "Chest Supported Row",
     ]);
     expect(updated.map((exercise) => exercise.supersetGroupId)).toEqual([
       null,
-      null,
-      null,
+      "superset-a",
+      "superset-a",
+    ]);
+  });
+
+  it("moves a superset past the entire adjacent superset block", () => {
+    const updated = moveExerciseBlock(
+      [
+        { ...exercises[0], name: "Bench Press", supersetGroupId: "superset-a" },
+        {
+          ...exercises[1],
+          name: "Chest Supported Row",
+          supersetGroupId: "superset-a",
+        },
+        { ...exercises[0], name: "Arnold Press", supersetGroupId: "superset-b" },
+        {
+          ...exercises[1],
+          name: "Barbell JM Press",
+          supersetGroupId: "superset-b",
+        },
+      ],
+      0,
+      "down",
+    );
+
+    expect(updated.map((exercise) => exercise.name)).toEqual([
+      "Arnold Press",
+      "Barbell JM Press",
+      "Bench Press",
+      "Chest Supported Row",
+    ]);
+    expect(updated.map((exercise) => exercise.supersetGroupId)).toEqual([
+      "superset-b",
+      "superset-b",
+      "superset-a",
+      "superset-a",
     ]);
   });
 

--- a/tests/lib/superset-utils.test.ts
+++ b/tests/lib/superset-utils.test.ts
@@ -120,6 +120,29 @@ describe("superset utilities", () => {
     ]);
   });
 
+  it("clears a split superset when a standalone exercise moves into the middle of it", () => {
+    const updated = moveExerciseBlock(
+      [
+        { ...exercises[0], supersetGroupId: "superset-a" },
+        { ...exercises[1], supersetGroupId: "superset-a" },
+        exercises[2],
+      ],
+      2,
+      "up",
+    );
+
+    expect(updated.map((exercise) => exercise.name)).toEqual([
+      "Bench Press",
+      "Bicep Curl",
+      "Chest Supported Row",
+    ]);
+    expect(updated.map((exercise) => exercise.supersetGroupId)).toEqual([
+      null,
+      null,
+      null,
+    ]);
+  });
+
   it("normalizes a leftover singleton group when deleting a grouped exercise", () => {
     const updated = removeExerciseAtIndex(
       [

--- a/tests/lib/superset-utils.test.ts
+++ b/tests/lib/superset-utils.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import {
+  groupExercisesForDisplay,
+  joinSupersetWithPrevious,
+  moveExerciseBlock,
+  removeExerciseAtIndex,
+  removeExerciseFromSuperset,
+  startSupersetWithNext,
+} from "@/lib/superset-utils";
+
+const exercises = [
+  {
+    name: "Bench Press",
+    notes: "",
+    supersetGroupId: null,
+    sets: [{ weight: "225", reps: "5", rpe: "8" }],
+  },
+  {
+    name: "Chest Supported Row",
+    notes: "",
+    supersetGroupId: null,
+    sets: [{ weight: "180", reps: "8", rpe: "8" }],
+  },
+  {
+    name: "Bicep Curl",
+    notes: "",
+    supersetGroupId: null,
+    sets: [{ weight: "40", reps: "12", rpe: "9" }],
+  },
+];
+
+describe("superset utilities", () => {
+  it("starts a superset with the next exercise using the supplied group id", () => {
+    const updated = startSupersetWithNext(exercises, 0, "superset-a");
+
+    expect(updated[0].supersetGroupId).toBe("superset-a");
+    expect(updated[1].supersetGroupId).toBe("superset-a");
+    expect(updated[2].supersetGroupId).toBeNull();
+  });
+
+  it("joins the previous superset when one exists", () => {
+    const updated = joinSupersetWithPrevious(
+      [
+        { ...exercises[0], supersetGroupId: "superset-a" },
+        { ...exercises[1], supersetGroupId: "superset-a" },
+        exercises[2],
+      ],
+      2,
+      () => "unused",
+    );
+
+    expect(updated.map((exercise) => exercise.supersetGroupId)).toEqual([
+      "superset-a",
+      "superset-a",
+      "superset-a",
+    ]);
+  });
+
+  it("creates a new pair when joining the previous exercise without an existing superset", () => {
+    const updated = joinSupersetWithPrevious(exercises, 1, () => "superset-b");
+
+    expect(updated.map((exercise) => exercise.supersetGroupId)).toEqual([
+      "superset-b",
+      "superset-b",
+      null,
+    ]);
+  });
+
+  it("removes one exercise from a pair and clears the remaining singleton group", () => {
+    const updated = removeExerciseFromSuperset(
+      [
+        { ...exercises[0], supersetGroupId: "superset-a" },
+        { ...exercises[1], supersetGroupId: "superset-a" },
+        exercises[2],
+      ],
+      0,
+    );
+
+    expect(updated.map((exercise) => exercise.supersetGroupId)).toEqual([
+      null,
+      null,
+      null,
+    ]);
+  });
+
+  it("removes a middle exercise from a larger superset and clears the split group", () => {
+    const updated = removeExerciseFromSuperset(
+      [
+        exercises[0],
+        { ...exercises[0], name: "Pulldown", supersetGroupId: "superset-a" },
+        { ...exercises[1], supersetGroupId: "superset-a" },
+        { ...exercises[2], supersetGroupId: "superset-a" },
+      ],
+      2,
+    );
+
+    expect(updated.map((exercise) => exercise.supersetGroupId)).toEqual([
+      null,
+      null,
+      null,
+      null,
+    ]);
+  });
+
+  it("moves an entire superset block when one member moves down", () => {
+    const updated = moveExerciseBlock(
+      [
+        { ...exercises[0], supersetGroupId: "superset-a" },
+        { ...exercises[1], supersetGroupId: "superset-a" },
+        exercises[2],
+      ],
+      1,
+      "down",
+    );
+
+    expect(updated.map((exercise) => exercise.name)).toEqual([
+      "Bicep Curl",
+      "Bench Press",
+      "Chest Supported Row",
+    ]);
+  });
+
+  it("normalizes a leftover singleton group when deleting a grouped exercise", () => {
+    const updated = removeExerciseAtIndex(
+      [
+        { ...exercises[0], supersetGroupId: "superset-a" },
+        { ...exercises[1], supersetGroupId: "superset-a" },
+        exercises[2],
+      ],
+      0,
+    );
+
+    expect(updated).toHaveLength(2);
+    expect(updated[0].name).toBe("Chest Supported Row");
+    expect(updated[0].supersetGroupId).toBeNull();
+  });
+
+  it("groups adjacent superset exercises into display blocks", () => {
+    const blocks = groupExercisesForDisplay([
+      { ...exercises[0], supersetGroupId: "superset-a" },
+      { ...exercises[1], supersetGroupId: "superset-a" },
+      exercises[2],
+    ]);
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toMatchObject({
+      kind: "superset",
+      supersetGroupId: "superset-a",
+      startIndex: 0,
+      endIndex: 1,
+    });
+    expect(blocks[0].exercises.map((exercise) => exercise.name)).toEqual([
+      "Bench Press",
+      "Chest Supported Row",
+    ]);
+    expect(blocks[1]).toMatchObject({
+      kind: "single",
+      startIndex: 2,
+      endIndex: 2,
+    });
+  });
+});

--- a/tests/lib/workout-form-schema.test.ts
+++ b/tests/lib/workout-form-schema.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { workoutFormSchema } from "@/lib/types";
+
+const validPayload = {
+  date: "2026-04-18",
+  name: "Push Day",
+  notes: "",
+  durationMinutes: 60,
+  exercises: [
+    {
+      name: "Bench Press",
+      notes: "",
+      supersetGroupId: "superset-a",
+      sets: [{ weight: "225", reps: "5", rpe: "8" }],
+    },
+    {
+      name: "Chest Supported Row",
+      notes: "",
+      supersetGroupId: "superset-a",
+      sets: [{ weight: "180", reps: "8", rpe: "8" }],
+    },
+    {
+      name: "Lateral Raise",
+      notes: "",
+      supersetGroupId: null,
+      sets: [{ weight: "20", reps: "15", rpe: "9" }],
+    },
+  ],
+};
+
+describe("workoutFormSchema superset validation", () => {
+  it("accepts adjacent exercises that share a superset group id", () => {
+    expect(workoutFormSchema.safeParse(validPayload).success).toBe(true);
+  });
+
+  it("rejects superset ids that appear on non-adjacent exercises", () => {
+    const result = workoutFormSchema.safeParse({
+      ...validPayload,
+      exercises: [
+        validPayload.exercises[0],
+        {
+          ...validPayload.exercises[1],
+          supersetGroupId: null,
+        },
+        {
+          ...validPayload.exercises[2],
+          supersetGroupId: "superset-a",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toContain("adjacent");
+  });
+
+  it("rejects a superset group with only one exercise", () => {
+    const result = workoutFormSchema.safeParse({
+      ...validPayload,
+      exercises: [
+        {
+          ...validPayload.exercises[0],
+          supersetGroupId: "solo-group",
+        },
+        {
+          ...validPayload.exercises[1],
+          supersetGroupId: null,
+        },
+        {
+          ...validPayload.exercises[2],
+          supersetGroupId: null,
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toContain("at least 2");
+  });
+});

--- a/tests/lib/workout-utils.test.ts
+++ b/tests/lib/workout-utils.test.ts
@@ -62,11 +62,14 @@ describe("copyWorkoutToClipboard", () => {
     });
   });
 
-  it("adds a Superset heading before grouped exercises", async () => {
+  it("adds explicit superset boundaries around grouped exercises", async () => {
     await copyWorkoutToClipboard(workoutFixture);
 
-    expect(writeTextMock).toHaveBeenCalledWith(expect.stringContaining("\nSuperset\nBench Press\n"));
-    expect(writeTextMock).toHaveBeenCalledWith(expect.stringContaining("Chest Supported Row"));
+    expect(writeTextMock).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "\nSuperset\nBench Press\nSet 1: 225 lbs x 5 reps @ RPE 8\n\nChest Supported Row\nSet 1: 180 lbs x 8 reps @ RPE 8\n\nEnd Superset\n\nBicep Curl\n",
+      ),
+    );
     expect(toastSuccessMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/lib/workout-utils.test.ts
+++ b/tests/lib/workout-utils.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { copyWorkoutToClipboard } from "@/lib/workout-utils";
+import type { Workout } from "@/lib/types";
+
+const { toastSuccessMock, toastErrorMock, writeTextMock } = vi.hoisted(() => ({
+  toastSuccessMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  writeTextMock: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: toastSuccessMock,
+    error: toastErrorMock,
+  },
+}));
+
+const workoutFixture: Workout = {
+  id: 1,
+  userId: "user-1",
+  name: "Push Day",
+  notes: "Strong session",
+  durationMinutes: 60,
+  date: "2026-04-18",
+  exercises: [
+    {
+      id: 10,
+      workoutId: 1,
+      name: "Bench Press",
+      notes: "",
+      supersetGroupId: "superset-a",
+      sets: [{ id: 100, exerciseId: 10, weight: "225", reps: "5", rpe: "8" }],
+    },
+    {
+      id: 11,
+      workoutId: 1,
+      name: "Chest Supported Row",
+      notes: "",
+      supersetGroupId: "superset-a",
+      sets: [{ id: 101, exerciseId: 11, weight: "180", reps: "8", rpe: "8" }],
+    },
+    {
+      id: 12,
+      workoutId: 1,
+      name: "Bicep Curl",
+      notes: "",
+      supersetGroupId: null,
+      sets: [{ id: 102, exerciseId: 12, weight: "40", reps: "12", rpe: "9" }],
+    },
+  ],
+};
+
+describe("copyWorkoutToClipboard", () => {
+  beforeEach(() => {
+    toastSuccessMock.mockReset();
+    toastErrorMock.mockReset();
+    writeTextMock.mockReset();
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: writeTextMock,
+      },
+    });
+  });
+
+  it("adds a Superset heading before grouped exercises", async () => {
+    await copyWorkoutToClipboard(workoutFixture);
+
+    expect(writeTextMock).toHaveBeenCalledWith(expect.stringContaining("\nSuperset\nBench Press\n"));
+    expect(writeTextMock).toHaveBeenCalledWith(expect.stringContaining("Chest Supported Row"));
+    expect(toastSuccessMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/routes/export-route.test.ts
+++ b/tests/routes/export-route.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { exercise, set, workout } from "@/db/schema";
+import { createRouteTestDatabase, destroyRouteTestDatabase, type RouteTestDatabase } from "@/tests/support/route-test-db";
+
+const { authMock, authState, dbRef } = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  authState: {
+    userId: null as string | null,
+  },
+  dbRef: {
+    current: null as RouteTestDatabase["db"] | null,
+  },
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: authMock,
+}));
+
+vi.mock("@/db/drizzle", () => ({
+  get db() {
+    if (!dbRef.current) {
+      throw new Error("Test database has not been initialized");
+    }
+
+    return dbRef.current;
+  },
+}));
+
+import { GET } from "@/app/api/export/route";
+
+describe("export route supersets", () => {
+  let database: RouteTestDatabase;
+
+  beforeEach(async () => {
+    database = await createRouteTestDatabase();
+    dbRef.current = database.db;
+    authState.userId = "user-1";
+    authMock.mockImplementation(async () => ({ userId: authState.userId }));
+  });
+
+  afterEach(async () => {
+    dbRef.current = null;
+    authState.userId = null;
+    await destroyRouteTestDatabase(database);
+  });
+
+  it("includes a Superset row before grouped exercises in csv exports", async () => {
+    const [insertedWorkout] = await database.db
+      .insert(workout)
+      .values({
+        userId: "user-1",
+        date: "2026-04-18",
+        name: "Push Day",
+        notes: "",
+        durationMinutes: 60,
+      })
+      .returning({ id: workout.id });
+
+    const [benchExercise] = await database.db
+      .insert(exercise)
+      .values({
+        workoutId: insertedWorkout.id,
+        name: "Bench Press",
+        notes: "",
+        supersetGroupId: "superset-a",
+      })
+      .returning({ id: exercise.id });
+
+    const [rowExercise] = await database.db
+      .insert(exercise)
+      .values({
+        workoutId: insertedWorkout.id,
+        name: "Chest Supported Row",
+        notes: "",
+        supersetGroupId: "superset-a",
+      })
+      .returning({ id: exercise.id });
+
+    await database.db.insert(set).values([
+      {
+        exerciseId: benchExercise.id,
+        weight: "225",
+        reps: "5",
+        rpe: "8",
+      },
+      {
+        exerciseId: rowExercise.id,
+        weight: "180",
+        reps: "8",
+        rpe: "8",
+      },
+    ]);
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/export?fileType=csv"),
+    );
+
+    expect(response.status).toBe(200);
+    const csvText = await response.text();
+
+    expect(csvText).toContain("Push Day");
+    expect(csvText).toContain("Superset");
+    expect(csvText).toContain("Bench Press");
+    expect(csvText).toContain("Chest Supported Row");
+    expect(csvText.indexOf("Superset")).toBeLessThan(
+      csvText.indexOf("Bench Press"),
+    );
+    expect(csvText.indexOf("Bench Press")).toBeLessThan(
+      csvText.indexOf("Chest Supported Row"),
+    );
+    expect(csvText.match(/Superset/g)).toHaveLength(1);
+  });
+});

--- a/tests/routes/workouts-routes.test.ts
+++ b/tests/routes/workouts-routes.test.ts
@@ -64,6 +64,7 @@ describe("workout route handlers", () => {
             {
               name: "Bench Press",
               notes: "Felt good",
+              supersetGroupId: "superset-a",
               sets: [
                 { weight: "225", reps: "5", rpe: "8" },
                 { weight: "235", reps: "3", rpe: "9" },
@@ -72,6 +73,7 @@ describe("workout route handlers", () => {
             {
               name: "Overhead Press",
               notes: "",
+              supersetGroupId: "superset-a",
               sets: [{ weight: "135", reps: "5", rpe: "8" }],
             },
           ],
@@ -109,6 +111,7 @@ describe("workout route handlers", () => {
       expect(workouts[0].exercises[0]).toMatchObject({
         name: "Bench Press",
         notes: "Felt good",
+        supersetGroupId: "superset-a",
       });
       expect(workouts[0].exercises[0].sets).toHaveLength(2);
       expect(workouts[0].exercises[1]).toMatchObject({
@@ -219,7 +222,14 @@ describe("workout route handlers", () => {
               {
                 name: "Deadlift",
                 notes: "Top single",
+                supersetGroupId: "superset-b",
                 sets: [{ weight: "405", reps: "1", rpe: "8.5" }],
+              },
+              {
+                name: "Pull Up",
+                notes: "Strict",
+                supersetGroupId: "superset-b",
+                sets: [{ weight: "bodyweight", reps: "8", rpe: "8" }],
               },
             ],
           },
@@ -252,16 +262,60 @@ describe("workout route handlers", () => {
         durationMinutes: 55,
         date: "2026-04-03",
       });
-      expect(updatedWorkout?.exercises).toHaveLength(1);
+      expect(updatedWorkout?.exercises).toHaveLength(2);
       expect(updatedWorkout?.exercises[0]).toMatchObject({
         name: "Deadlift",
         notes: "Top single",
+        supersetGroupId: "superset-b",
       });
       expect(updatedWorkout?.exercises[0].sets).toHaveLength(1);
       expect(updatedWorkout?.exercises[0].sets[0]).toMatchObject({
         weight: "405",
         reps: "1",
         rpe: "8.5",
+      });
+      expect(updatedWorkout?.exercises[1]).toMatchObject({
+        name: "Pull Up",
+        notes: "Strict",
+        supersetGroupId: "superset-b",
+      });
+    });
+
+    it("returns 400 for non-adjacent superset groups", async () => {
+      const response = await POST(
+        createJsonRequest("http://localhost/api/workouts", "POST", {
+          date: "2026-04-02",
+          name: "Push Day",
+          notes: "",
+          durationMinutes: 60,
+          exercises: [
+            {
+              name: "Bench Press",
+              notes: "",
+              supersetGroupId: "superset-a",
+              sets: [{ weight: "225", reps: "5", rpe: "8" }],
+            },
+            {
+              name: "Lateral Raise",
+              notes: "",
+              supersetGroupId: null,
+              sets: [{ weight: "20", reps: "15", rpe: "9" }],
+            },
+            {
+              name: "Cable Row",
+              notes: "",
+              supersetGroupId: "superset-a",
+              sets: [{ weight: "160", reps: "10", rpe: "8" }],
+            },
+          ],
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      await expect(getCounts(database)).resolves.toEqual({
+        workouts: 0,
+        exercises: 0,
+        sets: 0,
       });
     });
 
@@ -440,6 +494,7 @@ describe("workout route handlers", () => {
           {
             name: "Barbell Row",
             notes: "Straps on top set",
+            supersetGroupId: "superset-c",
             sets: [
               { weight: "225", reps: "8", rpe: "8" },
               { weight: "245", reps: "6", rpe: "9" },
@@ -448,6 +503,7 @@ describe("workout route handlers", () => {
           {
             name: "Lat Pulldown",
             notes: "Full stretch",
+            supersetGroupId: "superset-c",
             sets: [{ weight: "160", reps: "10", rpe: "8" }],
           },
         ],
@@ -468,6 +524,7 @@ describe("workout route handlers", () => {
           {
             name: "Barbell Row",
             notes: "Straps on top set",
+            supersetGroupId: "superset-c",
             sets: [
               { weight: "225", reps: "8", rpe: "8" },
               { weight: "245", reps: "6", rpe: "9" },
@@ -476,6 +533,7 @@ describe("workout route handlers", () => {
           {
             name: "Lat Pulldown",
             notes: "Full stretch",
+            supersetGroupId: "superset-c",
             sets: [{ weight: "160", reps: "10", rpe: "8" }],
           },
         ],
@@ -676,6 +734,7 @@ function validPayload() {
       {
         name: "Bench Press",
         notes: "",
+        supersetGroupId: null,
         sets: [{ weight: "225", reps: "5", rpe: "8" }],
       },
     ],

--- a/tests/support/route-test-db.ts
+++ b/tests/support/route-test-db.ts
@@ -14,6 +14,7 @@ export interface SeedWorkoutInput {
   exercises?: {
     name: string;
     notes?: string;
+    supersetGroupId?: string | null;
     sets?: {
       reps: string;
       weight: string;
@@ -55,6 +56,7 @@ export async function createRouteTestDatabase(): Promise<RouteTestDatabase> {
       id INTEGER PRIMARY KEY,
       name TEXT NOT NULL,
       notes TEXT NOT NULL,
+      superset_group_id TEXT,
       workout_id INTEGER NOT NULL REFERENCES workout(id) ON DELETE CASCADE
     )
   `);
@@ -117,6 +119,7 @@ export async function seedWorkout(
         workoutId: insertedWorkout.id,
         name: exerciseInput.name,
         notes: exerciseInput.notes ?? "",
+        supersetGroupId: exerciseInput.supersetGroupId ?? null,
       })
       .returning({ id: schema.exercise.id });
 

--- a/tests/workout-form/form-model.test.ts
+++ b/tests/workout-form/form-model.test.ts
@@ -51,6 +51,7 @@ const workoutFixture: Workout = {
       id: 11,
       name: "Bench Press",
       notes: "Original exercise notes",
+      supersetGroupId: "superset-a",
       workoutId: 1,
       sets: [
         { id: 111, weight: "225", reps: "5", rpe: "8", exerciseId: 11 },
@@ -102,6 +103,7 @@ describe("workout form seed builders", () => {
           {
             name: "",
             notes: "",
+            supersetGroupId: null,
             sets: [{ weight: "", reps: "", rpe: "" }],
           },
         ],
@@ -125,6 +127,7 @@ describe("workout form seed builders", () => {
           {
             name: "Bench Press",
             notes: "Original exercise notes",
+            supersetGroupId: "superset-a",
             sets: [
               { weight: "225", reps: "5", rpe: "8" },
               { weight: "235", reps: "3", rpe: "9" },
@@ -150,6 +153,7 @@ describe("workout form seed builders", () => {
           {
             name: "Bench Press",
             notes: "",
+            supersetGroupId: "superset-a",
             sets: [
               { weight: "", reps: "", rpe: "" },
               { weight: "", reps: "", rpe: "" },
@@ -161,6 +165,7 @@ describe("workout form seed builders", () => {
         "Bench Press": {
           name: "Bench Press",
           notes: "",
+          supersetGroupId: "superset-a",
           sets: [
             { weight: "225", reps: "5", rpe: "8" },
             { weight: "235", reps: "3", rpe: "9" },
@@ -178,16 +183,19 @@ describe("workout form seed builders", () => {
           ...workoutFixture.exercises[0],
           id: 21,
           name: "toString",
+          supersetGroupId: "reserved-group",
         },
         {
           ...workoutFixture.exercises[0],
           id: 22,
           name: "constructor",
+          supersetGroupId: "reserved-group",
         },
         {
           ...workoutFixture.exercises[0],
           id: 23,
           name: "__proto__",
+          supersetGroupId: "reserved-group",
         },
       ],
     });
@@ -197,15 +205,18 @@ describe("workout form seed builders", () => {
     ).toBe(Object.prototype);
     expect(duplicateSeed.templateValuesByExerciseName?.toString).toMatchObject({
       name: "toString",
+      supersetGroupId: "reserved-group",
     });
     expect(
       duplicateSeed.templateValuesByExerciseName?.constructor,
     ).toMatchObject({
       name: "constructor",
+      supersetGroupId: "reserved-group",
     });
     expect(duplicateSeed.templateValuesByExerciseName?.__proto__).toMatchObject(
       {
         name: "__proto__",
+        supersetGroupId: "reserved-group",
       },
     );
   });
@@ -230,6 +241,7 @@ describe("workout form seed builders", () => {
       "Bench Press": {
         name: "Bench Press",
         notes: "",
+        supersetGroupId: "superset-a",
         sets: [
           { weight: "225", reps: "5", rpe: "8" },
           { weight: "235", reps: "3", rpe: "9" },
@@ -247,12 +259,14 @@ describe("workout form seed builders", () => {
             ...workoutFixture.exercises[0],
             id: 21,
             name: "toString",
+            supersetGroupId: "reserved-group",
           },
           {
             ...workoutFixture.exercises[0],
             id: 22,
             name: "toString",
             notes: "second",
+            supersetGroupId: "reserved-group",
             sets: [
               { id: 221, weight: "245", reps: "2", rpe: "9.5", exerciseId: 22 },
             ],
@@ -261,6 +275,7 @@ describe("workout form seed builders", () => {
       }).templateValuesByExerciseName?.toString,
     ).toEqual({
       name: "toString",
+      supersetGroupId: "reserved-group",
       notes: "",
       sets: [
         { weight: "225", reps: "5", rpe: "8" },

--- a/tests/workout-form/save-workout.test.ts
+++ b/tests/workout-form/save-workout.test.ts
@@ -22,6 +22,7 @@ const workoutDraftFixture: WorkoutDraft = {
     {
       name: "Bench Press",
       notes: "Pause the first rep",
+      supersetGroupId: "superset-a",
       sets: [{ weight: "225", reps: "5", rpe: "8" }],
     },
   ],

--- a/tests/workout-form/workout-form-promotion.test.tsx
+++ b/tests/workout-form/workout-form-promotion.test.tsx
@@ -61,6 +61,7 @@ const workoutDraftFixture: WorkoutDraft = {
     {
       name: "Bench Press",
       notes: "Pause the first rep",
+      supersetGroupId: null,
       sets: [{ weight: "225", reps: "5", rpe: "8" }],
     },
   ],
@@ -157,6 +158,7 @@ describe("WorkoutForm promotion flow", () => {
           "Bench Press": {
             name: "Bench Press",
             notes: "",
+            supersetGroupId: null,
             sets: [{ weight: "200", reps: "6", rpe: "7" }],
           },
         }}
@@ -238,6 +240,7 @@ describe("WorkoutForm promotion flow", () => {
           "Bench Press": {
             name: "Bench Press",
             notes: "",
+            supersetGroupId: null,
             sets: [{ weight: "200", reps: "6", rpe: "7" }],
           },
         }}
@@ -263,6 +266,7 @@ describe("WorkoutForm promotion flow", () => {
             {
               name: "toString",
               notes: "",
+              supersetGroupId: null,
               sets: [{ weight: "", reps: "", rpe: "" }],
             },
           ],
@@ -282,6 +286,7 @@ describe("WorkoutForm promotion flow", () => {
       toString: {
         name: "toString",
         notes: "",
+        supersetGroupId: null,
         sets: [{ weight: "200", reps: "6", rpe: "7" }],
       },
     } as ExerciseTemplateValuesByName;
@@ -293,6 +298,7 @@ describe("WorkoutForm promotion flow", () => {
             {
               name: "toString",
               notes: "",
+              supersetGroupId: null,
               sets: [{ weight: "", reps: "", rpe: "" }],
             },
           ],
@@ -439,6 +445,7 @@ describe("WorkoutForm promotion flow", () => {
           "Bench Press": {
             name: "Bench Press",
             notes: "",
+            supersetGroupId: null,
             sets: [{ weight: "205", reps: "5", rpe: "8" }],
           },
         }}
@@ -521,6 +528,7 @@ describe("WorkoutForm promotion flow", () => {
           "Bench Press": {
             name: "Bench Press",
             notes: "",
+            supersetGroupId: null,
             sets: [{ weight: "200", reps: "6", rpe: "7" }],
           },
         }}

--- a/tests/workout-form/workout-form-supersets.test.tsx
+++ b/tests/workout-form/workout-form-supersets.test.tsx
@@ -1,0 +1,230 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { WorkoutDraft } from "@/components/workout-form/form-types";
+
+vi.mock("@/components/ui/sidebar", () => ({
+  SidebarTrigger: (props: React.ComponentProps<"button">) => (
+    <button type="button" {...props}>
+      Sidebar
+    </button>
+  ),
+}));
+
+vi.mock("@/components/workout-form/workout-form-header", () => ({
+  default: () => <div>Header</div>,
+}));
+
+vi.mock("@/components/workout-form/workout-form-action-header", () => ({
+  __esModule: true,
+  default: () => <div>Action Header</div>,
+}));
+
+vi.mock("@/components/workout-form/exercise-item", async () => ({
+  default: function MockExerciseItem({
+    exerciseName,
+    onMoveDown,
+    onRemove,
+    onRemoveFromSuperset,
+  }: {
+    exerciseName: string;
+    onMoveDown: () => void;
+    onRemove: () => void;
+    onRemoveFromSuperset: () => void;
+  }) {
+    return (
+      <div data-testid="exercise-item">
+        <span>{exerciseName}</span>
+        <button type="button" onClick={onMoveDown}>
+          move-down-{exerciseName}
+        </button>
+        <button type="button" onClick={onRemove}>
+          delete-{exerciseName}
+        </button>
+        <button type="button" onClick={onRemoveFromSuperset}>
+          remove-from-superset-{exerciseName}
+        </button>
+      </div>
+    );
+  },
+}));
+
+import WorkoutForm from "@/components/workout-form/workout-form";
+
+const twoExerciseSupersetFixture: WorkoutDraft = {
+  name: "Push Day",
+  date: "2026-04-18",
+  notes: "",
+  durationMinutes: 60,
+  exercises: [
+    {
+      name: "Bench Press",
+      notes: "",
+      supersetGroupId: null,
+      sets: [{ weight: "225", reps: "5", rpe: "8" }],
+    },
+    {
+      name: "Arnold Press",
+      notes: "",
+      supersetGroupId: "superset-a",
+      sets: [{ weight: "50", reps: "8", rpe: "8" }],
+    },
+    {
+      name: "Barbell JM Press",
+      notes: "",
+      supersetGroupId: "superset-a",
+      sets: [{ weight: "70", reps: "10", rpe: "9" }],
+    },
+    {
+      name: "Belt Squat",
+      notes: "",
+      supersetGroupId: null,
+      sets: [{ weight: "225", reps: "8", rpe: "8" }],
+    },
+  ],
+};
+
+const threeExerciseSupersetFixture: WorkoutDraft = {
+  ...twoExerciseSupersetFixture,
+  exercises: [
+    {
+      name: "Bench Press",
+      notes: "",
+      supersetGroupId: null,
+      sets: [{ weight: "225", reps: "5", rpe: "8" }],
+    },
+    {
+      name: "Arnold Press",
+      notes: "",
+      supersetGroupId: "superset-a",
+      sets: [{ weight: "50", reps: "8", rpe: "8" }],
+    },
+    {
+      name: "Barbell JM Press",
+      notes: "",
+      supersetGroupId: "superset-a",
+      sets: [{ weight: "70", reps: "10", rpe: "9" }],
+    },
+    {
+      name: "Belt Squat",
+      notes: "",
+      supersetGroupId: "superset-a",
+      sets: [{ weight: "225", reps: "8", rpe: "8" }],
+    },
+  ],
+};
+
+describe("WorkoutForm supersets", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders one Superset block for adjacent grouped exercises", () => {
+    render(
+      <WorkoutForm
+        initialValues={twoExerciseSupersetFixture}
+        persistMode="create"
+        exerciseNames={[
+          "Bench Press",
+          "Arnold Press",
+          "Barbell JM Press",
+          "Belt Squat",
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByText("Superset")).toHaveLength(1);
+  });
+
+  it("moves the entire superset block when one grouped exercise moves down", () => {
+    render(
+      <WorkoutForm
+        initialValues={twoExerciseSupersetFixture}
+        persistMode="create"
+        exerciseNames={[
+          "Bench Press",
+          "Arnold Press",
+          "Barbell JM Press",
+          "Belt Squat",
+        ]}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "move-down-Arnold Press" }),
+    );
+
+    expect(
+      screen.getAllByTestId("exercise-item").map((node) => node.textContent),
+    ).toEqual([
+      expect.stringContaining("Bench Press"),
+      expect.stringContaining("Belt Squat"),
+      expect.stringContaining("Arnold Press"),
+      expect.stringContaining("Barbell JM Press"),
+    ]);
+  });
+
+  it("deletes a grouped exercise without crashing and clears the orphaned superset", () => {
+    render(
+      <WorkoutForm
+        initialValues={twoExerciseSupersetFixture}
+        persistMode="update"
+        workoutId={251}
+        exerciseNames={[
+          "Bench Press",
+          "Arnold Press",
+          "Barbell JM Press",
+          "Belt Squat",
+        ]}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "delete-Arnold Press" }),
+    );
+
+    expect(screen.queryByText("Superset")).toBeNull();
+    expect(
+      screen.getAllByTestId("exercise-item").map((node) => node.textContent),
+    ).toEqual([
+      expect.stringContaining("Bench Press"),
+      expect.stringContaining("Barbell JM Press"),
+      expect.stringContaining("Belt Squat"),
+    ]);
+  });
+
+  it("removes the middle exercise from a larger superset and clears the split group", () => {
+    render(
+      <WorkoutForm
+        initialValues={threeExerciseSupersetFixture}
+        persistMode="update"
+        workoutId={250}
+        exerciseNames={[
+          "Bench Press",
+          "Arnold Press",
+          "Barbell JM Press",
+          "Belt Squat",
+        ]}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "remove-from-superset-Barbell JM Press",
+      }),
+    );
+
+    expect(screen.queryByText("Superset")).toBeNull();
+    expect(
+      screen.getAllByTestId("exercise-item").map((node) => node.textContent),
+    ).toEqual([
+      expect.stringContaining("Bench Press"),
+      expect.stringContaining("Arnold Press"),
+      expect.stringContaining("Barbell JM Press"),
+      expect.stringContaining("Belt Squat"),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add first-class superset support to workouts, including persistence, validation, and form actions
- render contiguous superset blocks in workout details, clipboard copy, and export output
- add regression coverage for superset creation, normalization, export formatting, and grouped exercise deletion

## Testing
- pnpm test
- pnpm lint
