### PR TITLE
[codex] Improve workout form UI

### DIFF
--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -60,10 +60,10 @@ function CommandDialog({
   );
 }
 
-function CommandInput({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+const CommandInput = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Input>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
+>(({ className, ...props }, ref) => {
   return (
     <div
       data-slot="command-input-wrapper"
@@ -71,6 +71,7 @@ function CommandInput({
     >
       <SearchIcon className="size-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input
+        ref={ref}
         data-slot="command-input"
         className={cn(
           "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
@@ -80,7 +81,8 @@ function CommandInput({
       />
     </div>
   );
-}
+});
+CommandInput.displayName = CommandPrimitive.Input.displayName;
 
 function CommandList({
   className,

--- a/components/workout-form/exercise-actions-menu.tsx
+++ b/components/workout-form/exercise-actions-menu.tsx
@@ -7,6 +7,7 @@ import {
   Link2,
   Link2Off,
   MoreVertical,
+  Pencil,
   Trash2,
 } from "lucide-react";
 import ExerciseHistoryModal from "@/components/exercise/exercise-history-modal";
@@ -20,6 +21,7 @@ import {
 interface ExerciseActionsMenuProps {
   exerciseName: string;
   workoutId?: number;
+  onChangeExercise?: () => void;
   onDelete: () => void;
   onMoveUp: () => void;
   onMoveDown: () => void;
@@ -36,6 +38,7 @@ interface ExerciseActionsMenuProps {
 export default function ExerciseActionsMenu({
   exerciseName,
   workoutId,
+  onChangeExercise,
   onDelete,
   onMoveUp,
   onMoveDown,
@@ -51,7 +54,13 @@ export default function ExerciseActionsMenu({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button type="button" variant="ghost" size="icon">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={`Exercise actions for ${exerciseName || "exercise"}`}
+          title={`Exercise actions for ${exerciseName || "exercise"}`}
+        >
           <MoreVertical />
         </Button>
       </DropdownMenuTrigger>
@@ -65,6 +74,12 @@ export default function ExerciseActionsMenu({
             View History
           </DropdownMenuItem>
         </ExerciseHistoryModal>
+        {onChangeExercise ? (
+          <DropdownMenuItem onClick={onChangeExercise}>
+            <Pencil />
+            Change Exercise
+          </DropdownMenuItem>
+        ) : null}
         <DropdownMenuItem onClick={onMoveUp} disabled={isFirst}>
           <ArrowUp />
           Move Up

--- a/components/workout-form/exercise-item.tsx
+++ b/components/workout-form/exercise-item.tsx
@@ -1,7 +1,8 @@
 "use client";
+import { useState } from "react";
 import { Controller, Control, UseFormGetValues } from "react-hook-form";
 import { Textarea } from "@/components/ui/textarea";
-import { Field, FieldError } from "@/components/ui/field";
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
 import ExerciseSelector from "@/components/workout-form/exercise-selector";
 import ExerciseActionsMenu from "@/components/workout-form/exercise-actions-menu";
 import FormSets from "@/components/workout-form/form-sets";
@@ -51,39 +52,61 @@ export default function ExerciseItem({
   workoutId,
   templateExercise,
 }: ExerciseItemProps) {
+  const exerciseTitle = exerciseName || `Exercise ${index + 1}`;
+  const [isChangingExercise, setIsChangingExercise] = useState(!exerciseName);
+  const shouldShowExerciseSelector = !exerciseName || isChangingExercise;
+
   return (
-    <div className="border-border bg-card space-y-4 rounded-lg border p-3 shadow-md shadow-black/25 sm:p-4">
-      <div className="flex items-center">
-        <Controller
-          control={control}
-          name={`exercises.${index}.name`}
-          render={({ field, fieldState }) => (
-            <Field className="flex-1">
-              <div className="flex items-center gap-2">
-                <ExerciseSelector
-                  value={field.value}
-                  onChange={field.onChange}
-                  exercises={exercises}
-                />
-                <ExerciseActionsMenu
-                  exerciseName={exerciseName}
-                  workoutId={workoutId}
-                  onDelete={onRemove}
-                  onMoveUp={onMoveUp}
-                  onMoveDown={onMoveDown}
-                  onStartSupersetWithNext={onStartSupersetWithNext}
-                  onJoinPreviousSuperset={onJoinPreviousSuperset}
-                  onRemoveFromSuperset={onRemoveFromSuperset}
-                  isFirst={isFirst}
-                  isLast={isLast}
-                  canStartSupersetWithNext={canStartSupersetWithNext}
-                  canJoinPreviousSuperset={canJoinPreviousSuperset}
-                  isInSuperset={isInSuperset}
-                />
-              </div>
-              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
-            </Field>
+    <div className="border-border bg-card min-w-0 space-y-4 rounded-lg border p-3 shadow-md shadow-black/25 sm:p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="text-muted-foreground text-xs font-semibold tracking-[0.18em] uppercase">
+            Exercise {index + 1}
+          </p>
+          {shouldShowExerciseSelector ? (
+            <Controller
+              control={control}
+              name={`exercises.${index}.name`}
+              render={({ field, fieldState }) => (
+                <Field className="mt-2">
+                  <FieldLabel className="sr-only">Exercise</FieldLabel>
+                  <ExerciseSelector
+                    value={field.value}
+                    onChange={(nextValue) => {
+                      field.onChange(nextValue);
+                      setIsChangingExercise(false);
+                    }}
+                    exercises={exercises}
+                  />
+                  {fieldState.invalid && (
+                    <FieldError errors={[fieldState.error]} />
+                  )}
+                </Field>
+              )}
+            />
+          ) : (
+            <h3 className="text-foreground truncate text-lg leading-7 font-bold">
+              {exerciseTitle}
+            </h3>
           )}
+        </div>
+        <ExerciseActionsMenu
+          exerciseName={exerciseName}
+          workoutId={workoutId}
+          onChangeExercise={
+            exerciseName ? () => setIsChangingExercise(true) : undefined
+          }
+          onDelete={onRemove}
+          onMoveUp={onMoveUp}
+          onMoveDown={onMoveDown}
+          onStartSupersetWithNext={onStartSupersetWithNext}
+          onJoinPreviousSuperset={onJoinPreviousSuperset}
+          onRemoveFromSuperset={onRemoveFromSuperset}
+          isFirst={isFirst}
+          isLast={isLast}
+          canStartSupersetWithNext={canStartSupersetWithNext}
+          canJoinPreviousSuperset={canJoinPreviousSuperset}
+          isInSuperset={isInSuperset}
         />
       </div>
 

--- a/components/workout-form/exercise-item.tsx
+++ b/components/workout-form/exercise-item.tsx
@@ -77,6 +77,13 @@ export default function ExerciseItem({
                       setIsChangingExercise(false);
                     }}
                     exercises={exercises}
+                    openOnMount={shouldShowExerciseSelector}
+                    hideTriggerWhenOpen={shouldShowExerciseSelector}
+                    onOpenChange={(nextOpen) => {
+                      if (!nextOpen && exerciseName) {
+                        setIsChangingExercise(false);
+                      }
+                    }}
                   />
                   {fieldState.invalid && (
                     <FieldError errors={[fieldState.error]} />

--- a/components/workout-form/exercise-selector.tsx
+++ b/components/workout-form/exercise-selector.tsx
@@ -75,14 +75,17 @@ export default function ExerciseSelector({
           <ChevronsUpDown />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-full p-0" align="start">
+      <PopoverContent
+        className="w-[calc(100vw-2rem)] max-w-md p-0 sm:w-[var(--radix-popover-trigger-width)]"
+        align="start"
+      >
         <Command shouldFilter={false}>
           <CommandInput
             placeholder="Search or add exercise..."
             className="h-11 text-base"
             onInput={(e) => setSearchValue(e.currentTarget.value)}
           />
-          <CommandList>
+          <CommandList className="max-h-[min(calc(100vh-13rem),24rem)]">
             <CommandEmpty>No matching exercises.</CommandEmpty>
             <CommandGroup>
               {filteredExercises.map((exercise) => (

--- a/components/workout-form/exercise-selector.tsx
+++ b/components/workout-form/exercise-selector.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Command,
@@ -36,6 +36,7 @@ export default function ExerciseSelector({
 }: ExerciseSelectorProps) {
   const [open, setOpen] = useState(openOnMount);
   const [searchValue, setSearchValue] = useState("");
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const displayValue = value || "Select exercise";
   const trimmedSearchValue = searchValue.trim();
   const normalizedSearchValue = trimmedSearchValue.toLocaleLowerCase();
@@ -50,6 +51,16 @@ export default function ExerciseSelector({
   );
   const shouldShowCreateOption =
     trimmedSearchValue.length > 0 && !hasExactExistingMatch;
+
+  useEffect(() => {
+    if (open) {
+      const focusTimeout = window.setTimeout(() => {
+        searchInputRef.current?.focus();
+      }, 0);
+
+      return () => window.clearTimeout(focusTimeout);
+    }
+  }, [open]);
 
   function handleOpenChange(nextOpen: boolean) {
     if (nextOpen) {
@@ -69,6 +80,8 @@ export default function ExerciseSelector({
   const commandSurface = (
     <Command shouldFilter={false}>
       <CommandInput
+        ref={searchInputRef}
+        autoFocus
         placeholder="Search or add exercise..."
         className="h-11 text-base"
         onInput={(e) => setSearchValue(e.currentTarget.value)}
@@ -134,7 +147,6 @@ export default function ExerciseSelector({
         className="w-[calc(100vw-2rem)] max-w-md p-0 sm:w-[var(--radix-popover-trigger-width)]"
         align="start"
         side="bottom"
-        avoidCollisions={false}
       >
         {commandSurface}
       </PopoverContent>

--- a/components/workout-form/exercise-selector.tsx
+++ b/components/workout-form/exercise-selector.tsx
@@ -72,6 +72,11 @@ export default function ExerciseSelector({
         placeholder="Search or add exercise..."
         className="h-11 text-base"
         onInput={(e) => setSearchValue(e.currentTarget.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Escape" && hideTriggerWhenOpen) {
+            handleOpenChange(false);
+          }
+        }}
       />
       <CommandList className="max-h-[min(calc(100vh-13rem),24rem)]">
         <CommandEmpty>No matching exercises.</CommandEmpty>

--- a/components/workout-form/exercise-selector.tsx
+++ b/components/workout-form/exercise-selector.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Command,
@@ -36,6 +36,7 @@ export default function ExerciseSelector({
 }: ExerciseSelectorProps) {
   const [open, setOpen] = useState(openOnMount);
   const [searchValue, setSearchValue] = useState("");
+  const directOpenSurfaceRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const displayValue = value || "Select exercise";
   const trimmedSearchValue = searchValue.trim();
@@ -62,14 +63,14 @@ export default function ExerciseSelector({
     }
   }, [open]);
 
-  function handleOpenChange(nextOpen: boolean) {
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
     if (nextOpen) {
       setSearchValue("");
     }
 
     setOpen(nextOpen);
     onOpenChange?.(nextOpen);
-  }
+  }, [onOpenChange]);
 
   function handleExerciseSelect(nextValue: string) {
     onChange(nextValue);
@@ -77,6 +78,30 @@ export default function ExerciseSelector({
   }
 
   const shouldHideTrigger = hideTriggerWhenOpen && open;
+
+  useEffect(() => {
+    if (!shouldHideTrigger) {
+      return;
+    }
+
+    function handlePointerDown(event: PointerEvent) {
+      const target = event.target;
+
+      if (
+        target instanceof Node &&
+        !directOpenSurfaceRef.current?.contains(target)
+      ) {
+        handleOpenChange(false);
+      }
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown);
+
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, [handleOpenChange, shouldHideTrigger]);
+
   const commandSurface = (
     <Command shouldFilter={false}>
       <CommandInput
@@ -120,7 +145,10 @@ export default function ExerciseSelector({
 
   if (shouldHideTrigger) {
     return (
-      <div className="bg-popover text-popover-foreground w-full overflow-hidden rounded-md border p-0 shadow-md">
+      <div
+        ref={directOpenSurfaceRef}
+        className="bg-popover text-popover-foreground w-full overflow-hidden rounded-md border p-0 shadow-md"
+      >
         {commandSurface}
       </div>
     );

--- a/components/workout-form/exercise-selector.tsx
+++ b/components/workout-form/exercise-selector.tsx
@@ -21,14 +21,20 @@ interface ExerciseSelectorProps {
   value: string;
   onChange: (value: string) => void;
   exercises: string[];
+  openOnMount?: boolean;
+  hideTriggerWhenOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export default function ExerciseSelector({
   value,
   onChange,
   exercises,
+  openOnMount = false,
+  hideTriggerWhenOpen = false,
+  onOpenChange,
 }: ExerciseSelectorProps) {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(openOnMount);
   const [searchValue, setSearchValue] = useState("");
   const displayValue = value || "Select exercise";
   const trimmedSearchValue = searchValue.trim();
@@ -51,11 +57,55 @@ export default function ExerciseSelector({
     }
 
     setOpen(nextOpen);
+    onOpenChange?.(nextOpen);
   }
 
   function handleExerciseSelect(nextValue: string) {
     onChange(nextValue);
-    setOpen(false);
+    handleOpenChange(false);
+  }
+
+  const shouldHideTrigger = hideTriggerWhenOpen && open;
+  const commandSurface = (
+    <Command shouldFilter={false}>
+      <CommandInput
+        placeholder="Search or add exercise..."
+        className="h-11 text-base"
+        onInput={(e) => setSearchValue(e.currentTarget.value)}
+      />
+      <CommandList className="max-h-[min(calc(100vh-13rem),24rem)]">
+        <CommandEmpty>No matching exercises.</CommandEmpty>
+        <CommandGroup>
+          {filteredExercises.map((exercise) => (
+            <CommandItem
+              value={exercise}
+              key={exercise}
+              onSelect={() => handleExerciseSelect(exercise)}
+              className="hover:bg-primary/10 cursor-pointer text-base transition-colors"
+            >
+              {exercise}
+            </CommandItem>
+          ))}
+          {shouldShowCreateOption && (
+            <CommandItem
+              value={trimmedSearchValue}
+              onSelect={() => handleExerciseSelect(trimmedSearchValue)}
+              className="hover:bg-primary/10 cursor-pointer text-base transition-colors"
+            >
+              Add &quot;{trimmedSearchValue}&quot;
+            </CommandItem>
+          )}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+
+  if (shouldHideTrigger) {
+    return (
+      <div className="bg-popover text-popover-foreground w-full overflow-hidden rounded-md border p-0 shadow-md">
+        {commandSurface}
+      </div>
+    );
   }
 
   return (
@@ -78,38 +128,10 @@ export default function ExerciseSelector({
       <PopoverContent
         className="w-[calc(100vw-2rem)] max-w-md p-0 sm:w-[var(--radix-popover-trigger-width)]"
         align="start"
+        side="bottom"
+        avoidCollisions={false}
       >
-        <Command shouldFilter={false}>
-          <CommandInput
-            placeholder="Search or add exercise..."
-            className="h-11 text-base"
-            onInput={(e) => setSearchValue(e.currentTarget.value)}
-          />
-          <CommandList className="max-h-[min(calc(100vh-13rem),24rem)]">
-            <CommandEmpty>No matching exercises.</CommandEmpty>
-            <CommandGroup>
-              {filteredExercises.map((exercise) => (
-                <CommandItem
-                  value={exercise}
-                  key={exercise}
-                  onSelect={() => handleExerciseSelect(exercise)}
-                  className="hover:bg-primary/10 cursor-pointer text-base transition-colors"
-                >
-                  {exercise}
-                </CommandItem>
-              ))}
-              {shouldShowCreateOption && (
-                <CommandItem
-                  value={trimmedSearchValue}
-                  onSelect={() => handleExerciseSelect(trimmedSearchValue)}
-                  className="hover:bg-primary/10 cursor-pointer text-base transition-colors"
-                >
-                  Add &quot;{trimmedSearchValue}&quot;
-                </CommandItem>
-              )}
-            </CommandGroup>
-          </CommandList>
-        </Command>
+        {commandSurface}
       </PopoverContent>
     </Popover>
   );

--- a/components/workout-form/form-sets.tsx
+++ b/components/workout-form/form-sets.tsx
@@ -28,18 +28,28 @@ export default function FormSets({
   });
 
   return (
-    <FieldSet className="flex flex-col gap-2">
+    <FieldSet className="flex min-w-0 flex-col gap-2">
       <FieldLegend
         variant="label"
         className="text-foreground/80 text-xs font-semibold tracking-[0.18em] uppercase"
       >
         Sets
       </FieldLegend>
+      <div className="text-muted-foreground grid grid-cols-[1.75rem_minmax(0,1fr)_minmax(0,0.8fr)_minmax(0,0.85fr)_2rem] items-center gap-1.5 px-1 text-center text-[0.68rem] font-semibold tracking-[0.16em] uppercase sm:gap-2">
+        <span className="text-left">Set</span>
+        <span>Weight</span>
+        <span>Reps</span>
+        <span>RPE</span>
+        <span className="sr-only">Actions</span>
+      </div>
       {fields.map((field, index) => (
         <div
           key={field.id}
-          className="flex items-center justify-between gap-2 rounded-md py-1"
+          className="grid grid-cols-[1.75rem_minmax(0,1fr)_minmax(0,0.8fr)_minmax(0,0.85fr)_2rem] items-center gap-1.5 rounded-md py-1 sm:gap-2"
         >
+          <div className="text-muted-foreground flex h-10 items-center justify-start pl-1 text-sm font-semibold tabular-nums">
+            {index + 1}
+          </div>
           <Controller
             name={`exercises.${exerciseIndex}.sets.${index}.weight`}
             control={control}
@@ -47,9 +57,10 @@ export default function FormSets({
               <Input
                 {...field}
                 id={field.name}
+                aria-label={`Set ${index + 1} weight`}
                 placeholder={templateExercise?.sets[index]?.weight ?? "Weight"}
                 inputMode="decimal"
-                className="h-10 w-20 text-center text-[16px]"
+                className="h-10 w-full px-1.5 text-center text-[16px] sm:px-2"
               />
             )}
           />
@@ -60,9 +71,10 @@ export default function FormSets({
               <Input
                 {...field}
                 id={field.name}
+                aria-label={`Set ${index + 1} reps`}
                 placeholder={templateExercise?.sets[index]?.reps ?? "Reps"}
                 inputMode="decimal"
-                className="h-10 w-16 text-center text-[16px]"
+                className="h-10 w-full px-1.5 text-center text-[16px] sm:px-2"
               />
             )}
           />
@@ -73,18 +85,21 @@ export default function FormSets({
               <Input
                 {...field}
                 id={field.name}
+                aria-label={`Set ${index + 1} RPE`}
                 placeholder={templateExercise?.sets[index]?.rpe ?? "RPE"}
                 inputMode="decimal"
-                className="h-10 w-20 text-center text-[16px]"
+                className="h-10 w-full px-1.5 text-center text-[16px] sm:px-2"
               />
             )}
           />
           <Button
             type="button"
             variant="ghost"
-            size="icon"
+            size="icon-sm"
             onClick={() => remove(index)}
-            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+            aria-label={`Delete set ${index + 1}`}
+            title={`Delete set ${index + 1}`}
+            className="text-destructive/80 hover:bg-destructive/10 hover:text-destructive"
           >
             <Trash2 size={20} />
           </Button>

--- a/components/workout-form/workout-form-header.tsx
+++ b/components/workout-form/workout-form-header.tsx
@@ -11,7 +11,7 @@ interface WorkoutFormHeaderProps {
 
 export default function WorkoutFormHeader({ control }: WorkoutFormHeaderProps) {
   return (
-    <div className="border-border bg-card grid grid-cols-1 gap-4 rounded-lg border p-4 shadow-md shadow-black/25 sm:gap-5 md:grid-cols-3">
+    <div className="border-border bg-card grid min-w-0 grid-cols-1 gap-4 rounded-lg border p-4 shadow-md shadow-black/25 sm:gap-5 md:grid-cols-3">
       <Controller
         name="date"
         control={control}
@@ -52,6 +52,46 @@ export default function WorkoutFormHeader({ control }: WorkoutFormHeaderProps) {
               placeholder="Enter workout name"
               {...field}
             />
+            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+          </Field>
+        )}
+      />
+      <Controller
+        name="durationMinutes"
+        control={control}
+        render={({ field, fieldState }) => (
+          <Field data-invalid={fieldState.invalid}>
+            <FieldLabel
+              htmlFor={field.name}
+              className="text-foreground/85 text-sm font-semibold"
+            >
+              Workout Duration
+            </FieldLabel>
+            <div className="relative w-36 max-w-full">
+              <Input
+                id={field.name}
+                aria-invalid={fieldState.invalid}
+                type="number"
+                min="1"
+                step="1"
+                inputMode="numeric"
+                className="h-10 w-36 max-w-full pr-10 text-center text-base tabular-nums sm:h-11 sm:pr-12"
+                value={field.value ?? ""}
+                onChange={(event) =>
+                  field.onChange(
+                    event.target.value === ""
+                      ? null
+                      : Number(event.target.value),
+                  )
+                }
+                onBlur={field.onBlur}
+                name={field.name}
+                ref={field.ref}
+              />
+              <span className="text-muted-foreground pointer-events-none absolute inset-y-0 right-2 flex items-center text-sm font-medium sm:right-3">
+                min
+              </span>
+            </div>
             {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
           </Field>
         )}

--- a/components/workout-form/workout-form-header.tsx
+++ b/components/workout-form/workout-form-header.tsx
@@ -11,29 +11,75 @@ interface WorkoutFormHeaderProps {
 
 export default function WorkoutFormHeader({ control }: WorkoutFormHeaderProps) {
   return (
-    <div className="border-border bg-card grid min-w-0 grid-cols-1 gap-4 rounded-lg border p-4 shadow-md shadow-black/25 sm:gap-5 md:grid-cols-3">
-      <Controller
-        name="date"
-        control={control}
-        render={({ field, fieldState }) => (
-          <Field data-invalid={fieldState.invalid}>
-            <FieldLabel
-              htmlFor={field.name}
-              className="text-foreground/85 text-sm font-semibold"
-            >
-              Date
-            </FieldLabel>
-            <Input
-              id={field.name}
-              aria-invalid={fieldState.invalid}
-              type="date"
-              className="h-10 w-full text-base sm:h-11"
-              {...field}
-            />
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
-          </Field>
-        )}
-      />
+    <div className="border-border bg-card grid min-w-0 grid-cols-1 gap-4 rounded-lg border p-4 shadow-md shadow-black/25 sm:gap-5 md:grid-cols-[minmax(0,1fr)_minmax(16rem,1.25fr)]">
+      <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_8rem] gap-3 sm:grid-cols-[minmax(0,1fr)_9rem] sm:gap-4">
+        <Controller
+          name="date"
+          control={control}
+          render={({ field, fieldState }) => (
+            <Field data-invalid={fieldState.invalid}>
+              <FieldLabel
+                htmlFor={field.name}
+                className="text-foreground/85 text-sm font-semibold"
+              >
+                Date
+              </FieldLabel>
+              <Input
+                id={field.name}
+                aria-invalid={fieldState.invalid}
+                type="date"
+                className="h-10 w-full text-base sm:h-11"
+                {...field}
+              />
+              {fieldState.invalid && (
+                <FieldError errors={[fieldState.error]} />
+              )}
+            </Field>
+          )}
+        />
+        <Controller
+          name="durationMinutes"
+          control={control}
+          render={({ field, fieldState }) => (
+            <Field data-invalid={fieldState.invalid}>
+              <FieldLabel
+                htmlFor={field.name}
+                className="text-foreground/85 text-sm font-semibold"
+              >
+                Workout Duration
+              </FieldLabel>
+              <div className="relative w-full">
+                <Input
+                  id={field.name}
+                  aria-invalid={fieldState.invalid}
+                  type="number"
+                  min="1"
+                  step="1"
+                  inputMode="numeric"
+                  className="h-10 w-full pr-9 text-center text-base tabular-nums sm:h-11 sm:pr-10"
+                  value={field.value ?? ""}
+                  onChange={(event) =>
+                    field.onChange(
+                      event.target.value === ""
+                        ? null
+                        : Number(event.target.value),
+                    )
+                  }
+                  onBlur={field.onBlur}
+                  name={field.name}
+                  ref={field.ref}
+                />
+                <span className="text-muted-foreground pointer-events-none absolute inset-y-0 right-2 flex items-center text-sm font-medium">
+                  min
+                </span>
+              </div>
+              {fieldState.invalid && (
+                <FieldError errors={[fieldState.error]} />
+              )}
+            </Field>
+          )}
+        />
+      </div>
       <Controller
         name="name"
         control={control}
@@ -57,50 +103,10 @@ export default function WorkoutFormHeader({ control }: WorkoutFormHeaderProps) {
         )}
       />
       <Controller
-        name="durationMinutes"
-        control={control}
-        render={({ field, fieldState }) => (
-          <Field data-invalid={fieldState.invalid}>
-            <FieldLabel
-              htmlFor={field.name}
-              className="text-foreground/85 text-sm font-semibold"
-            >
-              Workout Duration
-            </FieldLabel>
-            <div className="relative w-36 max-w-full">
-              <Input
-                id={field.name}
-                aria-invalid={fieldState.invalid}
-                type="number"
-                min="1"
-                step="1"
-                inputMode="numeric"
-                className="h-10 w-36 max-w-full pr-10 text-center text-base tabular-nums sm:h-11 sm:pr-12"
-                value={field.value ?? ""}
-                onChange={(event) =>
-                  field.onChange(
-                    event.target.value === ""
-                      ? null
-                      : Number(event.target.value),
-                  )
-                }
-                onBlur={field.onBlur}
-                name={field.name}
-                ref={field.ref}
-              />
-              <span className="text-muted-foreground pointer-events-none absolute inset-y-0 right-2 flex items-center text-sm font-medium sm:right-3">
-                min
-              </span>
-            </div>
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
-          </Field>
-        )}
-      />
-      <Controller
         name="notes"
         control={control}
         render={({ field, fieldState }) => (
-          <Field data-invalid={fieldState.invalid} className="md:col-span-3">
+          <Field data-invalid={fieldState.invalid} className="md:col-span-2">
             <FieldLabel
               htmlFor={field.name}
               className="text-foreground/85 text-sm font-semibold"

--- a/components/workout-form/workout-form.tsx
+++ b/components/workout-form/workout-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { Controller, useForm, useFieldArray, useWatch } from "react-hook-form";
+import { useForm, useFieldArray, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/components/ui/button";
 import ExerciseItem from "@/components/workout-form/exercise-item";
@@ -18,13 +18,9 @@ import type {
   WorkoutFormSeed,
 } from "@/components/workout-form/form-types";
 import {
-  Field,
-  FieldError,
-  FieldLabel,
   FieldLegend,
   FieldSet,
 } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
 import { saveWorkout } from "@/components/workout-form/save-workout";
 import {
   groupExercisesForDisplay,
@@ -273,11 +269,11 @@ export default function WorkoutForm(props: WorkoutFormProps) {
 
       <FieldSet
         disabled={isSubmitting}
-        className="mx-auto w-full max-w-3xl px-4 py-5 sm:px-6"
+        className="mx-auto w-full min-w-0 max-w-3xl px-4 py-5 sm:px-6"
       >
         <WorkoutFormHeader control={control} />
 
-        <FieldSet className="gap-4">
+        <FieldSet className="min-w-0 gap-4">
           <FieldLegend className="text-primary text-sm font-semibold tracking-[0.2em] uppercase">
             Exercises
           </FieldLegend>
@@ -393,56 +389,6 @@ export default function WorkoutForm(props: WorkoutFormProps) {
           </Button>
         </FieldSet>
 
-        <div className="border-border bg-card rounded-lg border p-4 shadow-md shadow-black/25">
-          <Controller
-            name="durationMinutes"
-            control={control}
-            render={({ field, fieldState }) => (
-              <Field
-                data-invalid={fieldState.invalid}
-                orientation="horizontal"
-                className="justify-between"
-              >
-                <FieldLabel
-                  htmlFor={field.name}
-                  className="text-foreground/85 text-sm font-semibold"
-                >
-                  Workout Duration
-                </FieldLabel>
-                <div className="w-32 shrink-0 sm:w-36">
-                  <div className="relative">
-                    <Input
-                      id={field.name}
-                      aria-invalid={fieldState.invalid}
-                      type="number"
-                      min="1"
-                      step="1"
-                      inputMode="numeric"
-                      className="h-11 w-full pr-12 text-center text-lg tabular-nums"
-                      value={field.value ?? ""}
-                      onChange={(event) =>
-                        field.onChange(
-                          event.target.value === ""
-                            ? null
-                            : Number(event.target.value),
-                        )
-                      }
-                      onBlur={field.onBlur}
-                      name={field.name}
-                      ref={field.ref}
-                    />
-                    <span className="text-muted-foreground pointer-events-none absolute inset-y-0 right-3 flex items-center text-sm font-medium">
-                      min
-                    </span>
-                  </div>
-                  {fieldState.invalid && (
-                    <FieldError errors={[fieldState.error]} />
-                  )}
-                </div>
-              </Field>
-            )}
-          />
-        </div>
       </FieldSet>
     </form>
   );

--- a/tests/components/exercise-actions-menu.test.tsx
+++ b/tests/components/exercise-actions-menu.test.tsx
@@ -76,6 +76,57 @@ describe("ExerciseActionsMenu", () => {
     expect(screen.queryByText("Remove From Superset")).toBeNull();
   });
 
+  it("labels the trigger for assistive technology", () => {
+    render(
+      <ExerciseActionsMenu
+        exerciseName="Bench Press"
+        onDelete={() => {}}
+        onMoveUp={() => {}}
+        onMoveDown={() => {}}
+        onStartSupersetWithNext={() => {}}
+        onJoinPreviousSuperset={() => {}}
+        onRemoveFromSuperset={() => {}}
+        isFirst={false}
+        isLast={false}
+        canStartSupersetWithNext={true}
+        canJoinPreviousSuperset={true}
+        isInSuperset={false}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Exercise actions for Bench Press",
+      }),
+    ).toBeTruthy();
+  });
+
+  it("shows a change exercise action when a callback is provided", () => {
+    const onChangeExercise = vi.fn();
+
+    render(
+      <ExerciseActionsMenu
+        exerciseName="Bench Press"
+        onChangeExercise={onChangeExercise}
+        onDelete={() => {}}
+        onMoveUp={() => {}}
+        onMoveDown={() => {}}
+        onStartSupersetWithNext={() => {}}
+        onJoinPreviousSuperset={() => {}}
+        onRemoveFromSuperset={() => {}}
+        isFirst={false}
+        isLast={false}
+        canStartSupersetWithNext={false}
+        canJoinPreviousSuperset={false}
+        isInSuperset={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Change Exercise"));
+
+    expect(onChangeExercise).toHaveBeenCalledTimes(1);
+  });
+
   it("shows remove from superset for grouped exercises and hides create actions", () => {
     render(
       <ExerciseActionsMenu

--- a/tests/workout-form/exercise-item-ui.test.tsx
+++ b/tests/workout-form/exercise-item-ui.test.tsx
@@ -11,15 +11,32 @@ vi.mock("@/components/workout-form/exercise-selector", () => ({
   default: ({
     value,
     onChange,
+    openOnMount,
+    hideTriggerWhenOpen,
   }: {
     value: string;
     onChange: (value: string) => void;
     exercises: string[];
-  }) => (
-    <button type="button" onClick={() => onChange("Overhead Press")}>
-      {value || "Select exercise"}
-    </button>
-  ),
+    openOnMount?: boolean;
+    hideTriggerWhenOpen?: boolean;
+  }) =>
+    openOnMount && hideTriggerWhenOpen ? (
+      <div
+        role="dialog"
+        data-open-on-mount={String(Boolean(openOnMount))}
+        onClick={() => onChange("Overhead Press")}
+      >
+        Selector open for {value || "new exercise"}
+      </div>
+    ) : (
+      <button
+        type="button"
+        data-open-on-mount={String(Boolean(openOnMount))}
+        onClick={() => onChange("Overhead Press")}
+      >
+        {value || "Select exercise"}
+      </button>
+    ),
 }));
 
 vi.mock("@/components/workout-form/exercise-actions-menu", () => ({
@@ -51,9 +68,21 @@ const workoutDraftFixture: WorkoutDraft = {
   ],
 };
 
-function ExerciseItemHarness() {
+function ExerciseItemHarness({
+  exerciseName = "Bench Press",
+}: {
+  exerciseName?: string;
+} = {}) {
   const form = useForm<WorkoutDraft>({
-    defaultValues: workoutDraftFixture,
+    defaultValues: {
+      ...workoutDraftFixture,
+      exercises: [
+        {
+          ...workoutDraftFixture.exercises[0],
+          name: exerciseName,
+        },
+      ],
+    },
   });
 
   return (
@@ -62,7 +91,7 @@ function ExerciseItemHarness() {
       control={form.control}
       getValues={form.getValues}
       exercises={["Bench Press", "Overhead Press"]}
-      exerciseName="Bench Press"
+      exerciseName={exerciseName}
       onRemove={() => {}}
       onMoveUp={() => {}}
       onMoveDown={() => {}}
@@ -100,7 +129,9 @@ describe("ExerciseItem UI", () => {
       screen.getByRole("button", { name: "Actions for Bench Press" }),
     );
 
-    expect(screen.getByRole("button", { name: "Bench Press" })).toBeTruthy();
+    expect(screen.getByRole("dialog").textContent).toBe(
+      "Selector open for Bench Press",
+    );
   });
 
   it("replaces the exercise heading with the selector when changing exercise", () => {
@@ -111,6 +142,32 @@ describe("ExerciseItem UI", () => {
     );
 
     expect(screen.queryByRole("heading", { name: "Bench Press" })).toBeNull();
-    expect(screen.getByRole("button", { name: "Bench Press" })).toBeTruthy();
+    expect(screen.getByRole("dialog").textContent).toBe(
+      "Selector open for Bench Press",
+    );
+  });
+
+  it("opens the selector immediately when changing exercise", () => {
+    render(<ExerciseItemHarness />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Actions for Bench Press" }),
+    );
+
+    expect(
+      screen
+        .getByRole("dialog")
+        .getAttribute("data-open-on-mount"),
+    ).toBe("true");
+  });
+
+  it("opens the selector immediately for blank exercises", () => {
+    render(<ExerciseItemHarness exerciseName="" />);
+
+    expect(
+      screen
+        .getByRole("dialog")
+        .getAttribute("data-open-on-mount"),
+    ).toBe("true");
   });
 });

--- a/tests/workout-form/exercise-item-ui.test.tsx
+++ b/tests/workout-form/exercise-item-ui.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import ExerciseItem from "@/components/workout-form/exercise-item";
+import type { WorkoutDraft } from "@/components/workout-form/form-types";
+
+vi.mock("@/components/workout-form/exercise-selector", () => ({
+  default: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    exercises: string[];
+  }) => (
+    <button type="button" onClick={() => onChange("Overhead Press")}>
+      {value || "Select exercise"}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/workout-form/exercise-actions-menu", () => ({
+  default: ({
+    exerciseName,
+    onChangeExercise,
+  }: {
+    exerciseName: string;
+    onChangeExercise?: () => void;
+  }) => (
+    <button type="button" onClick={onChangeExercise}>
+      Actions for {exerciseName}
+    </button>
+  ),
+}));
+
+const workoutDraftFixture: WorkoutDraft = {
+  name: "Push Day",
+  date: "2026-04-27",
+  notes: "",
+  durationMinutes: 60,
+  exercises: [
+    {
+      name: "Bench Press",
+      notes: "Pause the first rep",
+      supersetGroupId: null,
+      sets: [{ weight: "225", reps: "5", rpe: "8" }],
+    },
+  ],
+};
+
+function ExerciseItemHarness() {
+  const form = useForm<WorkoutDraft>({
+    defaultValues: workoutDraftFixture,
+  });
+
+  return (
+    <ExerciseItem
+      index={0}
+      control={form.control}
+      getValues={form.getValues}
+      exercises={["Bench Press", "Overhead Press"]}
+      exerciseName="Bench Press"
+      onRemove={() => {}}
+      onMoveUp={() => {}}
+      onMoveDown={() => {}}
+      onStartSupersetWithNext={() => {}}
+      onJoinPreviousSuperset={() => {}}
+      onRemoveFromSuperset={() => {}}
+      isFirst={true}
+      isLast={true}
+      canStartSupersetWithNext={false}
+      canJoinPreviousSuperset={false}
+      isInSuperset={false}
+    />
+  );
+}
+
+describe("ExerciseItem UI", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("gives selected exercises a scannable card heading", () => {
+    render(<ExerciseItemHarness />);
+
+    expect(
+      screen.getByRole("heading", { name: "Bench Press" }),
+    ).toBeTruthy();
+  });
+
+  it("hides the selector for named exercises until the action menu requests it", () => {
+    render(<ExerciseItemHarness />);
+
+    expect(screen.queryByRole("button", { name: "Bench Press" })).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Actions for Bench Press" }),
+    );
+
+    expect(screen.getByRole("button", { name: "Bench Press" })).toBeTruthy();
+  });
+
+  it("replaces the exercise heading with the selector when changing exercise", () => {
+    render(<ExerciseItemHarness />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Actions for Bench Press" }),
+    );
+
+    expect(screen.queryByRole("heading", { name: "Bench Press" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Bench Press" })).toBeTruthy();
+  });
+});

--- a/tests/workout-form/exercise-selector.test.tsx
+++ b/tests/workout-form/exercise-selector.test.tsx
@@ -136,6 +136,30 @@ describe("ExerciseSelector", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it("notifies direct-open callers when tapping outside closes the search surface", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <>
+        <button type="button">Outside target</button>
+        <ExerciseSelector
+          value="Bench Press"
+          onChange={() => {}}
+          exercises={["Bench Press", "Overhead Press"]}
+          openOnMount={true}
+          hideTriggerWhenOpen={true}
+          onOpenChange={onOpenChange}
+        />
+      </>,
+    );
+
+    await screen.findByPlaceholderText("Search or add exercise...");
+    await user.click(screen.getByRole("button", { name: "Outside target" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
   it('shows an add option for a non-empty custom value', async () => {
     const { user, input } = await renderSelector();
 

--- a/tests/workout-form/exercise-selector.test.tsx
+++ b/tests/workout-form/exercise-selector.test.tsx
@@ -72,6 +72,32 @@ describe("ExerciseSelector", () => {
     ).toBeTruthy();
   });
 
+  it("focuses the search input when opened immediately", async () => {
+    render(
+      <ExerciseSelector
+        value="Bench Press"
+        onChange={() => {}}
+        exercises={["Bench Press", "Overhead Press"]}
+        openOnMount={true}
+        hideTriggerWhenOpen={true}
+      />,
+    );
+
+    const input = await screen.findByPlaceholderText("Search or add exercise...");
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(input);
+    });
+  });
+
+  it("focuses the search input when the popover opens from the trigger", async () => {
+    const { input } = await renderSelector();
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(input);
+    });
+  });
+
   it("can hide the combobox trigger while the search surface is open", async () => {
     render(
       <ExerciseSelector

--- a/tests/workout-form/exercise-selector.test.tsx
+++ b/tests/workout-form/exercise-selector.test.tsx
@@ -89,6 +89,27 @@ describe("ExerciseSelector", () => {
     ).toBeTruthy();
   });
 
+  it("notifies direct-open callers when Escape closes the search surface", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <ExerciseSelector
+        value="Bench Press"
+        onChange={() => {}}
+        exercises={["Bench Press", "Overhead Press"]}
+        openOnMount={true}
+        hideTriggerWhenOpen={true}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    const input = await screen.findByPlaceholderText("Search or add exercise...");
+    await user.type(input, "{Escape}");
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
   it('shows an add option for a non-empty custom value', async () => {
     const { user, input } = await renderSelector();
 

--- a/tests/workout-form/exercise-selector.test.tsx
+++ b/tests/workout-form/exercise-selector.test.tsx
@@ -130,4 +130,19 @@ describe("ExerciseSelector", () => {
       expect(queryCreateOption("Romanian Deadlift")).toBeNull();
     });
   });
+
+  it("uses a mobile-friendly command surface", async () => {
+    await renderSelector();
+
+    const content = document.querySelector('[data-slot="popover-content"]');
+    const list = document.querySelector('[data-slot="command-list"]');
+
+    expect(content?.className).toContain("w-[calc(100vw-2rem)]");
+    expect(content?.className).toContain(
+      "sm:w-[var(--radix-popover-trigger-width)]",
+    );
+    expect(list?.className).toContain(
+      "max-h-[min(calc(100vh-13rem),24rem)]",
+    );
+  });
 });

--- a/tests/workout-form/exercise-selector.test.tsx
+++ b/tests/workout-form/exercise-selector.test.tsx
@@ -57,6 +57,38 @@ describe("ExerciseSelector", () => {
     expect(onChange).toHaveBeenCalledWith("Bench Press");
   });
 
+  it("can open the search surface immediately", async () => {
+    render(
+      <ExerciseSelector
+        value="Bench Press"
+        onChange={() => {}}
+        exercises={["Bench Press", "Overhead Press"]}
+        openOnMount={true}
+      />,
+    );
+
+    expect(
+      await screen.findByPlaceholderText("Search or add exercise..."),
+    ).toBeTruthy();
+  });
+
+  it("can hide the combobox trigger while the search surface is open", async () => {
+    render(
+      <ExerciseSelector
+        value="Bench Press"
+        onChange={() => {}}
+        exercises={["Bench Press", "Overhead Press"]}
+        openOnMount={true}
+        hideTriggerWhenOpen={true}
+      />,
+    );
+
+    expect(screen.queryByRole("combobox", { name: "Bench Press" })).toBeNull();
+    expect(
+      await screen.findByPlaceholderText("Search or add exercise..."),
+    ).toBeTruthy();
+  });
+
   it('shows an add option for a non-empty custom value', async () => {
     const { user, input } = await renderSelector();
 

--- a/tests/workout-form/form-sets-ui.test.tsx
+++ b/tests/workout-form/form-sets-ui.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import FormSets from "@/components/workout-form/form-sets";
+import type { WorkoutDraft } from "@/components/workout-form/form-types";
+
+const workoutDraftFixture: WorkoutDraft = {
+  name: "Push Day",
+  date: "2026-04-27",
+  notes: "",
+  durationMinutes: 60,
+  exercises: [
+    {
+      name: "Bench Press",
+      notes: "",
+      supersetGroupId: null,
+      sets: [
+        { weight: "225", reps: "5", rpe: "8" },
+        { weight: "215", reps: "6", rpe: "8.5" },
+      ],
+    },
+  ],
+};
+
+function FormSetsHarness() {
+  const form = useForm<WorkoutDraft>({
+    defaultValues: workoutDraftFixture,
+  });
+
+  return (
+    <FormSets
+      exerciseIndex={0}
+      control={form.control}
+      getValues={form.getValues}
+    />
+  );
+}
+
+describe("FormSets UI", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders set rows with visible numbers and accessible field labels", () => {
+    render(<FormSetsHarness />);
+
+    expect(screen.getByText("Set")).toBeTruthy();
+    expect(screen.getByText("Weight")).toBeTruthy();
+    expect(screen.getByText("Reps")).toBeTruthy();
+    expect(screen.getByText("RPE")).toBeTruthy();
+    expect(screen.getByText("1")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+
+    expect(screen.getByLabelText("Set 1 weight")).toBeTruthy();
+    expect(screen.getByLabelText("Set 1 reps")).toBeTruthy();
+    expect(screen.getByLabelText("Set 1 RPE")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Delete set 1" })).toBeTruthy();
+  });
+});

--- a/tests/workout-form/workout-form-promotion.test.tsx
+++ b/tests/workout-form/workout-form-promotion.test.tsx
@@ -228,7 +228,27 @@ describe("WorkoutForm promotion flow", () => {
 
     const durationInput = await screen.findByLabelText("Workout Duration");
 
-    expect(durationInput.className).toContain("w-36");
+    expect(durationInput.className).toContain("w-full");
+    expect(durationInput.className).toContain("text-center");
+  });
+
+  it("groups workout date and duration in a compact metadata row", async () => {
+    render(
+      <WorkoutForm
+        initialValues={buildWorkoutDraft()}
+        persistMode="update"
+        exerciseNames={exerciseNamesFixture}
+        workoutId={17}
+      />,
+    );
+
+    const dateInput = await screen.findByLabelText("Date");
+    const metadataRow = dateInput.closest('[data-slot="field"]')?.parentElement;
+
+    expect(metadataRow?.className).toContain(
+      "grid-cols-[minmax(0,1fr)_8rem]",
+    );
+    expect(metadataRow?.textContent).toContain("Workout Duration");
   });
 
   it("does not re-fill a cleared create date on rerender with the same seed", async () => {

--- a/tests/workout-form/workout-form-promotion.test.tsx
+++ b/tests/workout-form/workout-form-promotion.test.tsx
@@ -197,6 +197,40 @@ describe("WorkoutForm promotion flow", () => {
     });
   });
 
+  it("places workout duration before the exercise list", async () => {
+    render(
+      <WorkoutForm
+        initialValues={buildWorkoutDraft()}
+        persistMode="update"
+        exerciseNames={exerciseNamesFixture}
+        workoutId={17}
+      />,
+    );
+
+    const durationLabel = await screen.findByText("Workout Duration");
+    const exercisesLegend = screen.getByText("Exercises");
+
+    expect(
+      durationLabel.compareDocumentPosition(exercisesLegend) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("renders workout duration as a compact numeric field", async () => {
+    render(
+      <WorkoutForm
+        initialValues={buildWorkoutDraft()}
+        persistMode="update"
+        exerciseNames={exerciseNamesFixture}
+        workoutId={17}
+      />,
+    );
+
+    const durationInput = await screen.findByLabelText("Workout Duration");
+
+    expect(durationInput.className).toContain("w-36");
+  });
+
   it("does not re-fill a cleared create date on rerender with the same seed", async () => {
     vi.spyOn(Date.prototype, "toLocaleDateString").mockReturnValue(
       "2026-04-06",


### PR DESCRIPTION
## Summary

- Refines the workout form header with compact duration placement.
- Improves exercise cards with set-table labels, accessible set controls, and action-menu-driven exercise editing.
- Changes exercise editing and Add Exercise to open the exercise selector search surface directly instead of showing an intermediate combobox.
- Preserves light, dark, and system theme support.

## Validation

- pnpm lint
- pnpm test
- pnpm build
- In-app browser checks for exercise editing and Add Exercise selector behavior

## QA Notes

A broader in-app browser QA pass will be run after opening this PR, including regression coverage of the updated workout form flows.