### PR TITLE
Convert workout form to TanStack Form

### DIFF
--- a/components/workout-form/exercise-item.tsx
+++ b/components/workout-form/exercise-item.tsx
@@ -1,20 +1,19 @@
 "use client";
 import { useState } from "react";
-import { Controller, Control, UseFormGetValues } from "react-hook-form";
 import { Textarea } from "@/components/ui/textarea";
 import { Field, FieldError, FieldLabel } from "@/components/ui/field";
 import ExerciseSelector from "@/components/workout-form/exercise-selector";
 import ExerciseActionsMenu from "@/components/workout-form/exercise-actions-menu";
 import FormSets from "@/components/workout-form/form-sets";
-import type {
-  ExerciseTemplateValues,
-  WorkoutDraft,
-} from "@/components/workout-form/form-types";
+import {
+  getFieldErrors,
+  type WorkoutTanStackForm,
+} from "@/components/workout-form/tanstack-form";
+import type { ExerciseTemplateValues } from "@/components/workout-form/form-types";
 
 interface ExerciseItemProps {
   index: number;
-  control: Control<WorkoutDraft>;
-  getValues: UseFormGetValues<WorkoutDraft>;
+  form: WorkoutTanStackForm;
   exercises: string[];
   exerciseName: string;
   onRemove: () => void;
@@ -34,8 +33,7 @@ interface ExerciseItemProps {
 
 export default function ExerciseItem({
   index,
-  control,
-  getValues,
+  form,
   exercises,
   exerciseName,
   onRemove,
@@ -64,16 +62,14 @@ export default function ExerciseItem({
             Exercise {index + 1}
           </p>
           {shouldShowExerciseSelector ? (
-            <Controller
-              control={control}
-              name={`exercises.${index}.name`}
-              render={({ field, fieldState }) => (
+            <form.Field name={`exercises[${index}].name`}>
+              {(field) => (
                 <Field className="mt-2">
                   <FieldLabel className="sr-only">Exercise</FieldLabel>
                   <ExerciseSelector
-                    value={field.value}
+                    value={field.state.value}
                     onChange={(nextValue) => {
-                      field.onChange(nextValue);
+                      form.setFieldValue(`exercises[${index}].name`, nextValue);
                       setIsChangingExercise(false);
                     }}
                     exercises={exercises}
@@ -85,12 +81,10 @@ export default function ExerciseItem({
                       }
                     }}
                   />
-                  {fieldState.invalid && (
-                    <FieldError errors={[fieldState.error]} />
-                  )}
+                  <FieldError errors={getFieldErrors(field)} />
                 </Field>
               )}
-            />
+            </form.Field>
           ) : (
             <h3 className="text-foreground truncate text-lg leading-7 font-bold">
               {exerciseTitle}
@@ -119,27 +113,32 @@ export default function ExerciseItem({
 
       <FormSets
         exerciseIndex={index}
-        control={control}
-        getValues={getValues}
+        form={form}
         templateExercise={templateExercise}
       />
 
-      <Controller
-        control={control}
-        name={`exercises.${index}.notes`}
-        render={({ field, fieldState }) => (
-          <Field data-invalid={fieldState.invalid}>
+      <form.Field name={`exercises[${index}].notes`}>
+        {(field) => (
+          <Field data-invalid={!field.state.meta.isValid}>
             <Textarea
-              {...field}
               id={field.name}
-              aria-invalid={fieldState.invalid}
+              aria-invalid={!field.state.meta.isValid}
               placeholder="Add notes"
               className="resize-none text-base"
+              name={field.name}
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={(event) =>
+                form.setFieldValue(
+                  `exercises[${index}].notes`,
+                  event.target.value,
+                )
+              }
             />
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            <FieldError errors={getFieldErrors(field)} />
           </Field>
         )}
-      />
+      </form.Field>
     </div>
   );
 }

--- a/components/workout-form/form-sets.tsx
+++ b/components/workout-form/form-sets.tsx
@@ -1,148 +1,174 @@
 import { Input } from "@/components/ui/input";
-import { useFieldArray, Controller } from "react-hook-form";
-import { Control, UseFormGetValues } from "react-hook-form";
 import { FieldLegend, FieldSet } from "@/components/ui/field";
 import { Button } from "@/components/ui/button";
 import { Trash2 } from "lucide-react";
 import type {
-  ExerciseTemplateValues,
-  WorkoutDraft,
-} from "@/components/workout-form/form-types";
+  WorkoutFieldName,
+  WorkoutSetDraft,
+  WorkoutSetsFieldName,
+  WorkoutTanStackForm,
+} from "@/components/workout-form/tanstack-form";
+import type { ExerciseTemplateValues } from "@/components/workout-form/form-types";
 
 interface FormSetsProps {
   exerciseIndex: number;
-  control: Control<WorkoutDraft>;
-  getValues: UseFormGetValues<WorkoutDraft>;
+  form: WorkoutTanStackForm;
   templateExercise?: ExerciseTemplateValues;
+}
+
+const setFieldName = (
+  exerciseIndex: number,
+  setIndex: number,
+  fieldName: keyof WorkoutSetDraft,
+) =>
+  `exercises[${exerciseIndex}].sets[${setIndex}].${fieldName}` as WorkoutFieldName;
+
+const exerciseSetsFieldName = (exerciseIndex: number) =>
+  `exercises[${exerciseIndex}].sets` as WorkoutSetsFieldName;
+
+function SetValueField({
+  form,
+  fieldName,
+  label,
+  placeholder,
+}: {
+  form: WorkoutTanStackForm;
+  fieldName: WorkoutFieldName;
+  label: string;
+  placeholder: string;
+}) {
+  return (
+    <form.Field name={fieldName}>
+      {(field) => (
+        <Input
+          id={field.name}
+          aria-label={label}
+          placeholder={placeholder}
+          inputMode="decimal"
+          className="h-10 w-full px-1.5 text-center text-[16px] sm:px-2"
+          name={field.name}
+          value={String(field.state.value ?? "")}
+          onBlur={field.handleBlur}
+          onChange={(event) =>
+            form.setFieldValue(fieldName, event.target.value)
+          }
+        />
+      )}
+    </form.Field>
+  );
 }
 
 export default function FormSets({
   exerciseIndex,
-  control,
-  getValues,
+  form,
   templateExercise,
 }: FormSetsProps) {
-  const { fields, remove, append } = useFieldArray({
-    name: `exercises.${exerciseIndex}.sets`,
-    control,
-  });
+  const setsFieldName = exerciseSetsFieldName(exerciseIndex);
 
   return (
-    <FieldSet className="flex min-w-0 flex-col gap-2">
-      <FieldLegend
-        variant="label"
-        className="text-foreground/80 text-xs font-semibold tracking-[0.18em] uppercase"
-      >
-        Sets
-      </FieldLegend>
-      <div className="text-muted-foreground grid grid-cols-[1.75rem_minmax(0,1fr)_minmax(0,0.8fr)_minmax(0,0.85fr)_2rem] items-center gap-1.5 px-1 text-center text-[0.68rem] font-semibold tracking-[0.16em] uppercase sm:gap-2">
-        <span className="text-left">Set</span>
-        <span>Weight</span>
-        <span>Reps</span>
-        <span>RPE</span>
-        <span className="sr-only">Actions</span>
-      </div>
-      {fields.map((field, index) => (
-        <div
-          key={field.id}
-          className="grid grid-cols-[1.75rem_minmax(0,1fr)_minmax(0,0.8fr)_minmax(0,0.85fr)_2rem] items-center gap-1.5 rounded-md py-1 sm:gap-2"
-        >
-          <div className="text-muted-foreground flex h-10 items-center justify-start pl-1 text-sm font-semibold tabular-nums">
-            {index + 1}
+    <form.Field name={setsFieldName} mode="array">
+      {(setsField) => (
+        <FieldSet className="flex min-w-0 flex-col gap-2">
+          <FieldLegend
+            variant="label"
+            className="text-foreground/80 text-xs font-semibold tracking-[0.18em] uppercase"
+          >
+            Sets
+          </FieldLegend>
+          <div className="text-muted-foreground grid grid-cols-[1.75rem_minmax(0,1fr)_minmax(0,0.8fr)_minmax(0,0.85fr)_2rem] items-center gap-1.5 px-1 text-center text-[0.68rem] font-semibold tracking-[0.16em] uppercase sm:gap-2">
+            <span className="text-left">Set</span>
+            <span>Weight</span>
+            <span>Reps</span>
+            <span>RPE</span>
+            <span className="sr-only">Actions</span>
           </div>
-          <Controller
-            name={`exercises.${exerciseIndex}.sets.${index}.weight`}
-            control={control}
-            render={({ field }) => (
-              <Input
-                {...field}
-                id={field.name}
-                aria-label={`Set ${index + 1} weight`}
+          {setsField.state.value.map((_set: WorkoutSetDraft, index) => (
+            <div
+              key={index}
+              className="grid grid-cols-[1.75rem_minmax(0,1fr)_minmax(0,0.8fr)_minmax(0,0.85fr)_2rem] items-center gap-1.5 rounded-md py-1 sm:gap-2"
+            >
+              <div className="text-muted-foreground flex h-10 items-center justify-start pl-1 text-sm font-semibold tabular-nums">
+                {index + 1}
+              </div>
+              <SetValueField
+                form={form}
+                fieldName={setFieldName(exerciseIndex, index, "weight")}
+                label={`Set ${index + 1} weight`}
                 placeholder={templateExercise?.sets[index]?.weight ?? "Weight"}
-                inputMode="decimal"
-                className="h-10 w-full px-1.5 text-center text-[16px] sm:px-2"
               />
-            )}
-          />
-          <Controller
-            name={`exercises.${exerciseIndex}.sets.${index}.reps`}
-            control={control}
-            render={({ field }) => (
-              <Input
-                {...field}
-                id={field.name}
-                aria-label={`Set ${index + 1} reps`}
+              <SetValueField
+                form={form}
+                fieldName={setFieldName(exerciseIndex, index, "reps")}
+                label={`Set ${index + 1} reps`}
                 placeholder={templateExercise?.sets[index]?.reps ?? "Reps"}
-                inputMode="decimal"
-                className="h-10 w-full px-1.5 text-center text-[16px] sm:px-2"
               />
-            )}
-          />
-          <Controller
-            name={`exercises.${exerciseIndex}.sets.${index}.rpe`}
-            control={control}
-            render={({ field }) => (
-              <Input
-                {...field}
-                id={field.name}
-                aria-label={`Set ${index + 1} RPE`}
+              <SetValueField
+                form={form}
+                fieldName={setFieldName(exerciseIndex, index, "rpe")}
+                label={`Set ${index + 1} RPE`}
                 placeholder={templateExercise?.sets[index]?.rpe ?? "RPE"}
-                inputMode="decimal"
-                className="h-10 w-full px-1.5 text-center text-[16px] sm:px-2"
               />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => setsField.removeValue(index)}
+                aria-label={`Delete set ${index + 1}`}
+                title={`Delete set ${index + 1}`}
+                className="text-destructive/80 hover:bg-destructive/10 hover:text-destructive"
+              >
+                <Trash2 size={20} />
+              </Button>
+            </div>
+          ))}
+          <div className="flex gap-3 sm:gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                setsField.pushValue({
+                  weight: "",
+                  reps: "",
+                  rpe: "",
+                })
+              }
+            >
+              Add set
+            </Button>
+            {setsField.state.value.length > 0 && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  const lastSetIndex = setsField.state.value.length - 1;
+
+                  setsField.pushValue({
+                    weight: String(
+                      form.getFieldValue(
+                        setFieldName(exerciseIndex, lastSetIndex, "weight"),
+                      ) ?? "",
+                    ),
+                    reps: String(
+                      form.getFieldValue(
+                        setFieldName(exerciseIndex, lastSetIndex, "reps"),
+                      ) ?? "",
+                    ),
+                    rpe: String(
+                      form.getFieldValue(
+                        setFieldName(exerciseIndex, lastSetIndex, "rpe"),
+                      ) ?? "",
+                    ),
+                  });
+                }}
+              >
+                Clone set
+              </Button>
             )}
-          />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            onClick={() => remove(index)}
-            aria-label={`Delete set ${index + 1}`}
-            title={`Delete set ${index + 1}`}
-            className="text-destructive/80 hover:bg-destructive/10 hover:text-destructive"
-          >
-            <Trash2 size={20} />
-          </Button>
-        </div>
-      ))}
-      <div className="flex gap-3 sm:gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() =>
-            append({
-              weight: "",
-              reps: "",
-              rpe: "",
-            })
-          }
-        >
-          Add set
-        </Button>
-        {fields.length > 0 && (
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() =>
-              append({
-                weight: getValues(
-                  `exercises.${exerciseIndex}.sets.${fields.length - 1}.weight`,
-                ),
-                reps: getValues(
-                  `exercises.${exerciseIndex}.sets.${fields.length - 1}.reps`,
-                ),
-                rpe: getValues(
-                  `exercises.${exerciseIndex}.sets.${fields.length - 1}.rpe`,
-                ),
-              })
-            }
-          >
-            Clone set
-          </Button>
-        )}
-      </div>
-    </FieldSet>
+          </div>
+        </FieldSet>
+      )}
+    </form.Field>
   );
 }

--- a/components/workout-form/tanstack-form.ts
+++ b/components/workout-form/tanstack-form.ts
@@ -1,0 +1,46 @@
+import type {
+  DeepKeys,
+  DeepKeysOfType,
+  FormAsyncValidateOrFn,
+  FormValidateOrFn,
+  ReactFormExtendedApi,
+} from "@tanstack/react-form";
+
+import type { WorkoutDraft } from "@/components/workout-form/form-types";
+import type { workoutFormSchema } from "@/lib/types";
+
+export type WorkoutFieldName = DeepKeys<WorkoutDraft>;
+export type WorkoutSetDraft = WorkoutDraft["exercises"][number]["sets"][number];
+export type WorkoutSetsFieldName = DeepKeysOfType<
+  WorkoutDraft,
+  WorkoutSetDraft[]
+>;
+
+type WorkoutValidator = FormValidateOrFn<WorkoutDraft> | undefined;
+type WorkoutAsyncValidator = FormAsyncValidateOrFn<WorkoutDraft> | undefined;
+
+export type WorkoutTanStackForm = ReactFormExtendedApi<
+  WorkoutDraft,
+  WorkoutValidator,
+  WorkoutValidator,
+  WorkoutAsyncValidator,
+  WorkoutValidator,
+  WorkoutAsyncValidator,
+  typeof workoutFormSchema,
+  WorkoutAsyncValidator,
+  WorkoutValidator,
+  WorkoutAsyncValidator,
+  WorkoutAsyncValidator,
+  unknown
+>;
+
+export function getFieldErrors(field: {
+  state: {
+    meta: {
+      isValid: boolean;
+      errors: Array<{ message?: string } | undefined>;
+    };
+  };
+}) {
+  return field.state.meta.isValid ? undefined : field.state.meta.errors;
+}

--- a/components/workout-form/workout-form-header.tsx
+++ b/components/workout-form/workout-form-header.tsx
@@ -1,23 +1,23 @@
 "use client";
-import { Controller, Control } from "react-hook-form";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Field, FieldError, FieldLabel } from "@/components/ui/field";
-import type { TWorkoutFormSchema } from "@/lib/types";
+import {
+  getFieldErrors,
+  type WorkoutTanStackForm,
+} from "@/components/workout-form/tanstack-form";
 
 interface WorkoutFormHeaderProps {
-  control: Control<TWorkoutFormSchema>;
+  form: WorkoutTanStackForm;
 }
 
-export default function WorkoutFormHeader({ control }: WorkoutFormHeaderProps) {
+export default function WorkoutFormHeader({ form }: WorkoutFormHeaderProps) {
   return (
     <div className="border-border bg-card grid min-w-0 grid-cols-1 gap-4 rounded-lg border p-4 shadow-md shadow-black/25 sm:gap-5 md:grid-cols-[minmax(0,1fr)_minmax(16rem,1.25fr)]">
       <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_8rem] gap-3 sm:grid-cols-[minmax(0,1fr)_9rem] sm:gap-4">
-        <Controller
-          name="date"
-          control={control}
-          render={({ field, fieldState }) => (
-            <Field data-invalid={fieldState.invalid}>
+        <form.Field name="date">
+          {(field) => (
+            <Field data-invalid={!field.state.meta.isValid}>
               <FieldLabel
                 htmlFor={field.name}
                 className="text-foreground/85 text-sm font-semibold"
@@ -26,20 +26,23 @@ export default function WorkoutFormHeader({ control }: WorkoutFormHeaderProps) {
               </FieldLabel>
               <Input
                 id={field.name}
-                aria-invalid={fieldState.invalid}
+                aria-invalid={!field.state.meta.isValid}
                 type="date"
                 className="h-10 w-full text-base sm:h-11"
-                {...field}
+                name={field.name}
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(event) =>
+                  form.setFieldValue("date", event.target.value)
+                }
               />
-              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+              <FieldError errors={getFieldErrors(field)} />
             </Field>
           )}
-        />
-        <Controller
-          name="durationMinutes"
-          control={control}
-          render={({ field, fieldState }) => (
-            <Field data-invalid={fieldState.invalid}>
+        </form.Field>
+        <form.Field name="durationMinutes">
+          {(field) => (
+            <Field data-invalid={!field.state.meta.isValid}>
               <FieldLabel
                 htmlFor={field.name}
                 className="text-foreground/85 text-sm font-semibold"
@@ -49,38 +52,36 @@ export default function WorkoutFormHeader({ control }: WorkoutFormHeaderProps) {
               <div className="relative w-full">
                 <Input
                   id={field.name}
-                  aria-invalid={fieldState.invalid}
+                  aria-invalid={!field.state.meta.isValid}
                   type="number"
                   min="1"
                   step="1"
                   inputMode="numeric"
                   className="h-10 w-full pr-9 text-center text-base tabular-nums sm:h-11 sm:pr-10"
-                  value={field.value ?? ""}
+                  value={field.state.value ?? ""}
                   onChange={(event) =>
-                    field.onChange(
+                    form.setFieldValue(
+                      "durationMinutes",
                       event.target.value === ""
                         ? null
                         : Number(event.target.value),
                     )
                   }
-                  onBlur={field.onBlur}
+                  onBlur={field.handleBlur}
                   name={field.name}
-                  ref={field.ref}
                 />
                 <span className="text-muted-foreground pointer-events-none absolute inset-y-0 right-2 flex items-center text-sm font-medium">
                   min
                 </span>
               </div>
-              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+              <FieldError errors={getFieldErrors(field)} />
             </Field>
           )}
-        />
+        </form.Field>
       </div>
-      <Controller
-        name="name"
-        control={control}
-        render={({ field, fieldState }) => (
-          <Field data-invalid={fieldState.invalid}>
+      <form.Field name="name">
+        {(field) => (
+          <Field data-invalid={!field.state.meta.isValid}>
             <FieldLabel
               htmlFor={field.name}
               className="text-foreground/85 text-sm font-semibold"
@@ -89,20 +90,26 @@ export default function WorkoutFormHeader({ control }: WorkoutFormHeaderProps) {
             </FieldLabel>
             <Input
               id={field.name}
-              aria-invalid={fieldState.invalid}
+              aria-invalid={!field.state.meta.isValid}
               className="h-10 text-base sm:h-11"
               placeholder="Enter workout name"
-              {...field}
+              name={field.name}
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={(event) =>
+                form.setFieldValue("name", event.target.value)
+              }
             />
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            <FieldError errors={getFieldErrors(field)} />
           </Field>
         )}
-      />
-      <Controller
-        name="notes"
-        control={control}
-        render={({ field, fieldState }) => (
-          <Field data-invalid={fieldState.invalid} className="md:col-span-2">
+      </form.Field>
+      <form.Field name="notes">
+        {(field) => (
+          <Field
+            data-invalid={!field.state.meta.isValid}
+            className="md:col-span-2"
+          >
             <FieldLabel
               htmlFor={field.name}
               className="text-foreground/85 text-sm font-semibold"
@@ -111,15 +118,20 @@ export default function WorkoutFormHeader({ control }: WorkoutFormHeaderProps) {
             </FieldLabel>
             <Textarea
               id={field.name}
-              aria-invalid={fieldState.invalid}
+              aria-invalid={!field.state.meta.isValid}
               placeholder="Add overall workout notes"
               className="min-h-24 resize-y text-base"
-              {...field}
+              name={field.name}
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={(event) =>
+                form.setFieldValue("notes", event.target.value)
+              }
             />
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            <FieldError errors={getFieldErrors(field)} />
           </Field>
         )}
-      />
+      </form.Field>
     </div>
   );
 }

--- a/components/workout-form/workout-form.tsx
+++ b/components/workout-form/workout-form.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { useForm, useFieldArray, useWatch } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm, useStore } from "@tanstack/react-form";
 import { Button } from "@/components/ui/button";
 import ExerciseItem from "@/components/workout-form/exercise-item";
 import WorkoutFormHeader from "@/components/workout-form/workout-form-header";
@@ -17,10 +16,7 @@ import type {
   WorkoutFormProps,
   WorkoutFormSeed,
 } from "@/components/workout-form/form-types";
-import {
-  FieldLegend,
-  FieldSet,
-} from "@/components/ui/field";
+import { FieldLegend, FieldSet } from "@/components/ui/field";
 import { saveWorkout } from "@/components/workout-form/save-workout";
 import {
   groupExercisesForDisplay,
@@ -118,6 +114,8 @@ export default function WorkoutForm(props: WorkoutFormProps) {
   );
   const [localCreatePromotion, setLocalCreatePromotion] =
     useState<LocalCreatePromotion | null>(null);
+  const [formDefaultValues, setFormDefaultValues] =
+    useState<WorkoutDraft>(initialValues);
   const incomingFormSession: WorkoutFormSession = {
     persistMode,
     exerciseNames,
@@ -139,32 +137,62 @@ export default function WorkoutForm(props: WorkoutFormProps) {
   const hasSaveFailed = failedSaveSeedKey === incomingSeedKey;
   const appliedSeedKeyRef = useRef(incomingSeedKey);
   const initializedDateSeedKeyRef = useRef<string | null>(null);
-  const form = useForm<WorkoutDraft>({
-    resolver: zodResolver(workoutFormSchema),
-    defaultValues: initialValues,
+  const form = useForm({
+    defaultValues: formDefaultValues,
+    validators: {
+      onSubmit: workoutFormSchema,
+    },
+    listeners: {
+      onChange: () => {
+        if (hasSaveFailed) {
+          setFailedSaveSeedKey(null);
+        }
+      },
+    },
+    onSubmit: async () => {
+      const submittedSnapshot = cloneWorkoutForm(form.state.values);
+      setFailedSaveSeedKey(null);
+
+      const result = await saveWorkout({
+        persistMode: formSession.persistMode,
+        workoutId: formSession.workoutId,
+        values: submittedSnapshot,
+      });
+
+      if (!result.ok) {
+        setFailedSaveSeedKey(incomingSeedKey);
+        return;
+      }
+
+      setFailedSaveSeedKey(null);
+      setFormDefaultValues(submittedSnapshot);
+      form.reset(submittedSnapshot);
+
+      if (formSession.persistMode === "create") {
+        setLocalCreatePromotion({
+          sourceSeedKey: incomingSeedKey,
+          workoutId: result.workoutId,
+        });
+        window.history.replaceState(
+          window.history.state,
+          "",
+          `/workouts/edit/${result.workoutId}`,
+        );
+      }
+    },
   });
-  const {
-    control,
-    getValues,
-    handleSubmit,
-    reset,
-    setValue,
-    subscribe,
-    formState: { isDirty, isSubmitting },
-  } = form;
-  const { fields, append, replace } = useFieldArray({
-    control,
-    name: "exercises",
-  });
-  const watchedExercises = useWatch({
-    control,
-    name: "exercises",
-  });
-  const currentExercises = watchedExercises ?? getValues("exercises");
-  const renderExercises = fields.map((field, index) => ({
-    id: field.id,
-    name: currentExercises[index]?.name ?? "",
-    supersetGroupId: currentExercises[index]?.supersetGroupId ?? null,
+  const { isDirty, isSubmitting } = useStore(form.store, (state) => ({
+    isDirty: state.isDirty,
+    isSubmitting: state.isSubmitting,
+  }));
+  const currentExercises = useStore(
+    form.store,
+    (state) => state.values.exercises,
+  );
+  const renderExercises = currentExercises.map((exercise, index) => ({
+    id: `${exercise.name}-${exercise.supersetGroupId ?? "single"}-${index}`,
+    name: exercise.name,
+    supersetGroupId: exercise.supersetGroupId,
   }));
   const exerciseBlocks = groupExercisesForDisplay(renderExercises);
   const saveStatus = getSaveStatus({
@@ -180,8 +208,18 @@ export default function WorkoutForm(props: WorkoutFormProps) {
     }
 
     appliedSeedKeyRef.current = incomingSeedKey;
-    reset(initialValues);
-  }, [incomingSeedKey, initialValues, reset]);
+    form.reset(initialValues);
+    let shouldSyncDefaults = true;
+    queueMicrotask(() => {
+      if (shouldSyncDefaults) {
+        setFormDefaultValues(initialValues);
+      }
+    });
+
+    return () => {
+      shouldSyncDefaults = false;
+    };
+  }, [form, incomingSeedKey, initialValues]);
 
   useEffect(() => {
     if (formSession.persistMode !== "create") {
@@ -192,86 +230,40 @@ export default function WorkoutForm(props: WorkoutFormProps) {
       return;
     }
 
-    if (getValues("date")) {
+    if (form.getFieldValue("date")) {
       initializedDateSeedKeyRef.current = incomingSeedKey;
       return;
     }
 
     initializedDateSeedKeyRef.current = incomingSeedKey;
-    setValue("date", getBrowserTodayDate(), {
-      shouldDirty: false,
-      shouldTouch: false,
+    form.setFieldValue("date", getBrowserTodayDate(), {
+      dontUpdateMeta: true,
     });
-  }, [formSession.persistMode, getValues, incomingSeedKey, setValue]);
-
-  useEffect(() => {
-    if (!hasSaveFailed) {
-      return;
-    }
-
-    const unsubscribe = subscribe({
-      formState: { values: true },
-      callback: ({ name, type }) => {
-        if (!name || type === "blur") {
-          return;
-        }
-
-        setFailedSaveSeedKey(null);
-        unsubscribe();
-      },
-    });
-
-    return () => {
-      unsubscribe();
-    };
-  }, [hasSaveFailed, subscribe]);
-
-  const onSubmit = async (values: WorkoutDraft) => {
-    const submittedSnapshot = cloneWorkoutForm(values);
-    setFailedSaveSeedKey(null);
-
-    const result = await saveWorkout({
-      persistMode: formSession.persistMode,
-      workoutId: formSession.workoutId,
-      values: submittedSnapshot,
-    });
-
-    if (!result.ok) {
-      setFailedSaveSeedKey(incomingSeedKey);
-      return;
-    }
-
-    setFailedSaveSeedKey(null);
-    reset(submittedSnapshot);
-
-    if (formSession.persistMode === "create") {
-      setLocalCreatePromotion({
-        sourceSeedKey: incomingSeedKey,
-        workoutId: result.workoutId,
-      });
-      window.history.replaceState(
-        window.history.state,
-        "",
-        `/workouts/edit/${result.workoutId}`,
-      );
-    }
-  };
+  }, [form, formSession.persistMode, incomingSeedKey]);
 
   const replaceExercises = (exercises: WorkoutDraft["exercises"]) => {
-    replace(exercises);
+    form.setFieldValue("exercises", exercises);
   };
 
   const createSupersetGroupId = () => globalThis.crypto.randomUUID();
 
   return (
-    <form noValidate onSubmit={handleSubmit(onSubmit)} aria-busy={isSubmitting}>
+    <form
+      noValidate
+      onSubmit={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        void form.handleSubmit();
+      }}
+      aria-busy={isSubmitting}
+    >
       <WorkoutFormActionHeader saveStatus={saveStatus} />
 
       <FieldSet
         disabled={isSubmitting}
-        className="mx-auto w-full min-w-0 max-w-3xl px-4 py-5 sm:px-6"
+        className="mx-auto w-full max-w-3xl min-w-0 px-4 py-5 sm:px-6"
       >
-        <WorkoutFormHeader control={control} />
+        <WorkoutFormHeader form={form} />
 
         <FieldSet className="min-w-0 gap-4">
           <FieldLegend className="text-primary text-sm font-semibold tracking-[0.2em] uppercase">
@@ -281,7 +273,6 @@ export default function WorkoutForm(props: WorkoutFormProps) {
           {exerciseBlocks.map((block) => {
             const blockContent = block.exercises.map((_, offset) => {
               const index = block.startIndex + offset;
-              const field = fields[index];
               const exerciseName = renderExercises[index]?.name ?? "";
               const exerciseGroupId =
                 renderExercises[index]?.supersetGroupId ?? null;
@@ -291,37 +282,43 @@ export default function WorkoutForm(props: WorkoutFormProps) {
                   formSession.templateValuesByExerciseName,
               });
 
-              if (!field) {
-                return null;
-              }
-
               return (
                 <ExerciseItem
-                  key={field.id}
+                  key={renderExercises[index]?.id ?? index}
                   index={index}
-                  control={control}
-                  getValues={getValues}
+                  form={form}
                   exercises={formSession.exerciseNames}
                   exerciseName={exerciseName}
                   onRemove={() =>
                     replaceExercises(
-                      removeExerciseAtIndex(getValues("exercises"), index),
+                      removeExerciseAtIndex(
+                        form.getFieldValue("exercises"),
+                        index,
+                      ),
                     )
                   }
                   onMoveUp={() =>
                     replaceExercises(
-                      moveExerciseBlock(getValues("exercises"), index, "up"),
+                      moveExerciseBlock(
+                        form.getFieldValue("exercises"),
+                        index,
+                        "up",
+                      ),
                     )
                   }
                   onMoveDown={() =>
                     replaceExercises(
-                      moveExerciseBlock(getValues("exercises"), index, "down"),
+                      moveExerciseBlock(
+                        form.getFieldValue("exercises"),
+                        index,
+                        "down",
+                      ),
                     )
                   }
                   onStartSupersetWithNext={() =>
                     replaceExercises(
                       startSupersetWithNext(
-                        getValues("exercises"),
+                        form.getFieldValue("exercises"),
                         index,
                         createSupersetGroupId(),
                       ),
@@ -330,7 +327,7 @@ export default function WorkoutForm(props: WorkoutFormProps) {
                   onJoinPreviousSuperset={() =>
                     replaceExercises(
                       joinSupersetWithPrevious(
-                        getValues("exercises"),
+                        form.getFieldValue("exercises"),
                         index,
                         createSupersetGroupId,
                       ),
@@ -338,7 +335,10 @@ export default function WorkoutForm(props: WorkoutFormProps) {
                   }
                   onRemoveFromSuperset={() =>
                     replaceExercises(
-                      removeExerciseFromSuperset(getValues("exercises"), index),
+                      removeExerciseFromSuperset(
+                        form.getFieldValue("exercises"),
+                        index,
+                      ),
                     )
                   }
                   isFirst={block.startIndex === 0}
@@ -377,7 +377,7 @@ export default function WorkoutForm(props: WorkoutFormProps) {
             type="button"
             variant="outline"
             onClick={() =>
-              append({
+              form.pushFieldValue("exercises", {
                 name: "",
                 notes: "",
                 supersetGroupId: null,
@@ -388,7 +388,6 @@ export default function WorkoutForm(props: WorkoutFormProps) {
             Add Exercise
           </Button>
         </FieldSet>
-
       </FieldSet>
     </form>
   );

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^7.0.8",
-    "@hookform/resolvers": "^5.2.2",
     "@libsql/client": "^0.17.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -27,6 +26,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@tanstack/react-form": "^1.29.1",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.1",
@@ -38,7 +38,6 @@
     "next-themes": "^0.4.6",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-hook-form": "^7.72.1",
     "sonner": "^2.0.3",
     "swr": "^2.4.1",
     "xlsx": "^0.18.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@clerk/nextjs':
         specifier: ^7.0.8
         version: 7.0.8(next@16.2.2(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@hookform/resolvers':
-        specifier: ^5.2.2
-        version: 5.2.2(react-hook-form@7.72.1(react@19.2.4))
       '@libsql/client':
         specifier: ^0.17.2
         version: 0.17.2
@@ -41,6 +38,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-form':
+        specifier: ^1.29.1
+        version: 1.29.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.2(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
@@ -74,9 +74,6 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
-      react-hook-form:
-        specifier: ^7.72.1
-        version: 7.72.1(react@19.2.4)
       sonner:
         specifier: ^2.0.3
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -832,11 +829,6 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
-
-  '@hookform/resolvers@5.2.2':
-    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
-    peerDependencies:
-      react-hook-form: ^7.55.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1667,9 +1659,6 @@ packages:
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
-  '@standard-schema/utils@0.3.0':
-    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
-
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1761,8 +1750,38 @@ packages:
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
 
+  '@tanstack/devtools-event-client@0.4.3':
+    resolution: {integrity: sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@tanstack/form-core@1.29.1':
+    resolution: {integrity: sha512-NIYPO36eEu7nSWvMpbFDQaBWyVtnH/C8fsZ3/XpJUT4uOWgmxsiUvHGbTbDNIQTXAKIkhwEl0sUrqBNn2SfUnw==}
+
+  '@tanstack/pacer-lite@0.1.1':
+    resolution: {integrity: sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w==}
+    engines: {node: '>=18'}
+
   '@tanstack/query-core@5.90.16':
     resolution: {integrity: sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==}
+
+  '@tanstack/react-form@1.29.1':
+    resolution: {integrity: sha512-hVHk4g0phd0HxRsv2ry6Xt8BqmalT55Q3cokhJBCC1St0hcGZhgwJJbohm9atao45BPG9e55DGvtbwExqZe35g==}
+    peerDependencies:
+      '@tanstack/react-start': '*'
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@tanstack/react-start':
+        optional: true
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -3432,12 +3451,6 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
-  react-hook-form@7.72.1:
-    resolution: {integrity: sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: ^16.8.0 || ^17 || ^18 || ^19
-
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -4524,11 +4537,6 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@hookform/resolvers@5.2.2(react-hook-form@7.72.1(react@19.2.4))':
-    dependencies:
-      '@standard-schema/utils': 0.3.0
-      react-hook-form: 7.72.1(react@19.2.4)
-
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -5239,8 +5247,6 @@ snapshots:
 
   '@stablelib/base64@1.0.1': {}
 
-  '@standard-schema/utils@0.3.0': {}
-
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -5314,7 +5320,34 @@ snapshots:
       postcss: 8.5.8
       tailwindcss: 4.2.2
 
+  '@tanstack/devtools-event-client@0.4.3': {}
+
+  '@tanstack/form-core@1.29.1':
+    dependencies:
+      '@tanstack/devtools-event-client': 0.4.3
+      '@tanstack/pacer-lite': 0.1.1
+      '@tanstack/store': 0.9.3
+
+  '@tanstack/pacer-lite@0.1.1': {}
+
   '@tanstack/query-core@5.90.16': {}
+
+  '@tanstack/react-form@1.29.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/form-core': 1.29.1
+      '@tanstack/react-store': 0.9.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+    transitivePeerDependencies:
+      - react-dom
+
+  '@tanstack/react-store@0.9.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      use-sync-external-store: 1.6.0(react@19.2.4)
+
+  '@tanstack/store@0.9.3': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -7018,10 +7051,6 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
-
-  react-hook-form@7.72.1(react@19.2.4):
-    dependencies:
-      react: 19.2.4
 
   react-is@16.13.1: {}
 

--- a/tests/workout-form/exercise-item-ui.test.tsx
+++ b/tests/workout-form/exercise-item-ui.test.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { useForm } from "react-hook-form";
+import { useForm } from "@tanstack/react-form";
 import ExerciseItem from "@/components/workout-form/exercise-item";
 import type { WorkoutDraft } from "@/components/workout-form/form-types";
 
@@ -88,8 +88,7 @@ function ExerciseItemHarness({
   return (
     <ExerciseItem
       index={0}
-      control={form.control}
-      getValues={form.getValues}
+      form={form}
       exercises={["Bench Press", "Overhead Press"]}
       exerciseName={exerciseName}
       onRemove={() => {}}
@@ -115,9 +114,7 @@ describe("ExerciseItem UI", () => {
   it("gives selected exercises a scannable card heading", () => {
     render(<ExerciseItemHarness />);
 
-    expect(
-      screen.getByRole("heading", { name: "Bench Press" }),
-    ).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Bench Press" })).toBeTruthy();
   });
 
   it("hides the selector for named exercises until the action menu requests it", () => {
@@ -154,20 +151,16 @@ describe("ExerciseItem UI", () => {
       screen.getByRole("button", { name: "Actions for Bench Press" }),
     );
 
-    expect(
-      screen
-        .getByRole("dialog")
-        .getAttribute("data-open-on-mount"),
-    ).toBe("true");
+    expect(screen.getByRole("dialog").getAttribute("data-open-on-mount")).toBe(
+      "true",
+    );
   });
 
   it("opens the selector immediately for blank exercises", () => {
     render(<ExerciseItemHarness exerciseName="" />);
 
-    expect(
-      screen
-        .getByRole("dialog")
-        .getAttribute("data-open-on-mount"),
-    ).toBe("true");
+    expect(screen.getByRole("dialog").getAttribute("data-open-on-mount")).toBe(
+      "true",
+    );
   });
 });

--- a/tests/workout-form/form-sets-ui.test.tsx
+++ b/tests/workout-form/form-sets-ui.test.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
-import { useForm } from "react-hook-form";
+import { useForm } from "@tanstack/react-form";
 import FormSets from "@/components/workout-form/form-sets";
 import type { WorkoutDraft } from "@/components/workout-form/form-types";
 
@@ -30,13 +30,7 @@ function FormSetsHarness() {
     defaultValues: workoutDraftFixture,
   });
 
-  return (
-    <FormSets
-      exerciseIndex={0}
-      control={form.control}
-      getValues={form.getValues}
-    />
-  );
+  return <FormSets exerciseIndex={0} form={form} />;
 }
 
 describe("FormSets UI", () => {

--- a/tests/workout-form/workout-form-tanstack-migration.test.ts
+++ b/tests/workout-form/workout-form-tanstack-migration.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const workoutFormFiles = [
+  "components/workout-form/workout-form.tsx",
+  "components/workout-form/workout-form-header.tsx",
+  "components/workout-form/exercise-item.tsx",
+  "components/workout-form/form-sets.tsx",
+];
+
+describe("WorkoutForm TanStack Form migration", () => {
+  it("removes react-hook-form from the main workout form modules", () => {
+    for (const file of workoutFormFiles) {
+      const source = readFileSync(join(process.cwd(), file), "utf8");
+
+      expect(source, file).not.toContain("react-hook-form");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Migrated the main workout form from `react-hook-form` to TanStack Form across the workout form shell, header, exercise item, and set editors.
- Updated the form typing and field helpers so the form uses TanStack APIs directly for validation, array handling, exercise reordering, and superset flows.
- Added migration coverage to ensure the workout form modules no longer import `react-hook-form` and updated the affected UI tests to render with TanStack Form.

## Testing
- `pnpm test`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm build`
- Manual browser verification on the authenticated app for create, edit, duplicate, validation, set cloning/deletion, exercise reorder/delete, superset create/remove, save, reload, and console error checks